### PR TITLE
Do NOT close the database handle on restart; simply detach the relevant

### DIFF
--- a/lib/proxy/reverse.c
+++ b/lib/proxy/reverse.c
@@ -2704,7 +2704,16 @@ int proxy_reverse_init(pool *p, const char *tables_dir) {
 }
 
 int proxy_reverse_free(pool *p) {
+  int res;
+
   /* TODO: Implement any necessary cleanup */
+  res = proxy_db_close(p, PROXY_REVERSE_DB_SCHEMA_NAME);
+  if (res < 0) {
+    (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
+      "error detaching database with schema '%s': %s",
+      PROXY_REVERSE_DB_SCHEMA_NAME, strerror(errno));
+  }
+
   return 0;
 }
 
@@ -2763,7 +2772,7 @@ int proxy_reverse_sess_free(pool *p, struct proxy_session *proxy_sess) {
   reverse_flags = 0UL;
   reverse_retry_count = PROXY_DEFAULT_RETRY_COUNT;
 
-  proxy_db_close(p, PROXY_REVERSE_DB_SCHEMA_NAME);
+  (void) proxy_db_close(p, PROXY_REVERSE_DB_SCHEMA_NAME);
   return 0;
 }
 

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -2734,6 +2734,15 @@ int proxy_tls_init(pool *p, const char *tables_dir) {
 }
 
 int proxy_tls_free(pool *p) {
+  int res;
+
+  res = proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME);
+  if (res < 0) {
+    (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
+      "error detaching database with schema '%s': %s",
+      PROXY_TLS_DB_SCHEMA_NAME, strerror(errno));
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
schema, knowing that they will reattach during postparse.  Only close the
entire database handle on shutdown.  This should hopefully reduce chances
of "corruption".

Addresses Issue #64 .