### PR TITLE
Redesign the Proxy Database API, such that API consumers now get thei…

### DIFF
--- a/include/proxy/db.h
+++ b/include/proxy/db.h
@@ -27,30 +27,32 @@
 
 #include "mod_proxy.h"
 
+struct proxy_dbh;
+
 int proxy_db_init(pool *p);
 int proxy_db_free(void);
 
 /* Create/prepare the database (with the given schema name) at the given path */
-int proxy_db_open(pool *p, const char *table_path, const char *schema_name);
+struct proxy_dbh *proxy_db_open(pool *p, const char *table_path);
 
 /* Create/prepare the database (with the given schema name) at the given path.
  * If the database/schema already exists, check that its schema version is
  * greater than or equal to the given minimum version.  If not, delete that
  * database and create a new one.
  */
-int proxy_db_open_with_version(pool *p, const char *table_path,
+struct proxy_dbh *proxy_db_open_with_version(pool *p, const char *table_path,
   const char *schema_name, unsigned int schema_version, int flags);
 #define PROXY_DB_OPEN_FL_ERROR_ON_SCHEMA_VERSION_SKEW		0x001
 #define PROXY_DB_OPEN_FL_SKIP_INTEGRITY_CHECK			0x002
 #define PROXY_DB_OPEN_FL_SKIP_VACUUM				0x004
 
 /* Close the database. */
-int proxy_db_close(pool *p, const char *schema_name);
+int proxy_db_close(pool *p, struct proxy_dbh *dbh);
 
-int proxy_db_prepare_stmt(pool *p, const char *stmt);
-int proxy_db_finish_stmt(pool *p, const char *stmt);
-int proxy_db_bind_stmt(pool *p, const char *stmt, int idx, int type,
-  void *data);
+int proxy_db_prepare_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt);
+int proxy_db_finish_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt);
+int proxy_db_bind_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt,
+  int idx, int type, void *data);
 #define PROXY_DB_BIND_TYPE_INT		1
 #define PROXY_DB_BIND_TYPE_LONG		2
 #define PROXY_DB_BIND_TYPE_TEXT		3
@@ -59,13 +61,15 @@ int proxy_db_bind_stmt(pool *p, const char *stmt, int idx, int type,
 /* Executes the given statement.  Assumes that the caller is not using a SELECT,
  * and/or is uninterested in the statement results.
  */
-int proxy_db_exec_stmt(pool *p, const char *stmt, const char **errstr);
-
-/* Executes the given statement as a previously prepared statement. */
-array_header *proxy_db_exec_prepared_stmt(pool *p, const char *stmt,
+int proxy_db_exec_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt,
   const char **errstr);
 
+/* Executes the given statement as a previously prepared statement. */
+array_header *proxy_db_exec_prepared_stmt(pool *p, struct proxy_dbh *dbh,
+  const char *stmt, const char **errstr);
+
 /* Rebuild the named index. */
-int proxy_db_reindex(pool *p, const char *index_name, const char **errstr);
+int proxy_db_reindex(pool *p, struct proxy_dbh *dbh, const char *index_name,
+  const char **errstr);
 
 #endif /* MOD_PROXY_DB_H */

--- a/include/proxy/db.h
+++ b/include/proxy/db.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy database API
- * Copyright (c) 2015-2016 TJ Saunders
+ * Copyright (c) 2015-2017 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -33,7 +33,8 @@ int proxy_db_init(pool *p);
 int proxy_db_free(void);
 
 /* Create/prepare the database (with the given schema name) at the given path */
-struct proxy_dbh *proxy_db_open(pool *p, const char *table_path);
+struct proxy_dbh *proxy_db_open(pool *p, const char *table_path,
+  const char *schema_name);
 
 /* Create/prepare the database (with the given schema name) at the given path.
  * If the database/schema already exists, check that its schema version is

--- a/lib/proxy/db.c
+++ b/lib/proxy/db.c
@@ -711,6 +711,8 @@ int proxy_db_close(pool *p, struct proxy_dbh *dbh) {
     return -1;
   }
 
+  pr_trace_msg(trace_channel, 19, "closing '%s' database handle",
+    dbh->schema_name);
   tmp_pool = make_sub_pool(p);
 
   /* Make sure to close/finish any prepared statements associated with

--- a/lib/proxy/db.c
+++ b/lib/proxy/db.c
@@ -481,7 +481,7 @@ struct proxy_dbh *proxy_db_open(pool *p, const char *table_path,
   }
 
   if (pr_trace_get_level(trace_channel) >= PROXY_DB_SQLITE_TRACE_LEVEL) {
-    sqlite3_trace(db, db_trace, schema_name);
+    sqlite3_trace(db, db_trace, (void *) schema_name);
   }
 
   sub_pool = make_sub_pool(p);

--- a/lib/proxy/db.c
+++ b/lib/proxy/db.c
@@ -42,7 +42,7 @@ static const char *trace_channel = "proxy.db";
 
 static void db_err(void *user_data, int err_code, const char *err_msg) {
   if (current_schema != NULL) {
-    pr_trace_msg(trace_channel, 1, "(sqlite3): schema %s: [error %d] %s",
+    pr_trace_msg(trace_channel, 1, "(sqlite3): schema '%s': [error %d] %s",
       current_schema, err_code, err_msg);
 
   } else {
@@ -57,7 +57,7 @@ static void db_trace(void *user_data, const char *trace_msg) {
 
     schema = user_data;
     pr_trace_msg(trace_channel, PROXY_DB_SQLITE_TRACE_LEVEL,
-      "(sqlite3): schema %s: %s", schema, trace_msg);
+      "(sqlite3): schema '%s': %s", schema, trace_msg);
 
   } else {
     pr_trace_msg(trace_channel, PROXY_DB_SQLITE_TRACE_LEVEL,
@@ -171,7 +171,7 @@ int proxy_db_prepare_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt) {
   res = sqlite3_prepare_v2(dbh->db, stmt, -1, &pstmt, NULL);
   if (res != SQLITE_OK) {
     pr_trace_msg(trace_channel, 4,
-      "schema %s: error preparing statement '%s': %s", dbh->schema, stmt,
+      "schema '%s': error preparing statement '%s': %s", dbh->schema, stmt,
       sqlite3_errmsg(dbh->db));
     errno = EINVAL;
     return -1;
@@ -333,7 +333,7 @@ int proxy_db_finish_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt) {
   res = sqlite3_finalize(pstmt);
   if (res != SQLITE_OK) {
     pr_trace_msg(trace_channel, 3,
-      "schema %s: error finishing prepared statement '%s': %s", dbh->schema,
+      "schema '%s': error finishing prepared statement '%s': %s", dbh->schema,
       stmt, sqlite3_errmsg(dbh->db));
     errno = EPERM;
     return -1;
@@ -409,8 +409,8 @@ array_header *proxy_db_exec_prepared_stmt(pool *p, struct proxy_dbh *dbh,
 
     ncols = sqlite3_column_count(pstmt);
     pr_trace_msg(trace_channel, 12,
-      "schema %s: executing prepared statement '%s' returned row (columns: %d)",
-      dbh->schema, stmt, ncols);
+      "schema '%s': executing prepared statement '%s' returned row "
+      "(columns: %d)", dbh->schema, stmt, ncols);
 
     for (i = 0; i < ncols; i++) {
       char *val = NULL;
@@ -440,7 +440,7 @@ array_header *proxy_db_exec_prepared_stmt(pool *p, struct proxy_dbh *dbh,
 
     current_schema = NULL;
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
-      "schema %s: executing prepared statement '%s' did not complete "
+      "schema '%s': executing prepared statement '%s' did not complete "
       "successfully: %s", dbh->schema, stmt, errmsg);
     errno = EPERM;
     return NULL;
@@ -597,7 +597,7 @@ static int set_schema_version(pool *p, struct proxy_dbh *dbh,
     xerrno = errno;
 
     (void) pr_log_debug(DEBUG3, MOD_PROXY_VERSION
-      ": schema %s: error preparing statement '%s': %s", dbh->schema, stmt,
+      ": schema '%s': error preparing statement '%s': %s", dbh->schema, stmt,
       strerror(xerrno));
     errno = xerrno;
     return -1;
@@ -761,7 +761,7 @@ int proxy_db_close(pool *p, struct proxy_dbh *dbh) {
     res = sqlite3_finalize(pstmt);
     if (res != SQLITE_OK) {
       pr_trace_msg(trace_channel, 2,
-        "schema %s: error finishing prepared statement '%s': %s", dbh->schema,
+        "schema '%s': error finishing prepared statement '%s': %s", dbh->schema,
         sql, sqlite3_errmsg(dbh->db));
 
     } else {

--- a/lib/proxy/db.c
+++ b/lib/proxy/db.c
@@ -497,7 +497,7 @@ array_header *proxy_db_exec_prepared_stmt(pool *p, struct proxy_dbh *dbh,
 
 struct proxy_dbh *proxy_db_open(pool *p, const char *table_path,
     const char *schema_name) {
-  int res, res;
+  int res, flags;
   pool *sub_pool;
   const char *stmt;
   sqlite3 *db = NULL;

--- a/lib/proxy/reverse.c
+++ b/lib/proxy/reverse.c
@@ -382,7 +382,7 @@ static int reverse_db_add_schema(pool *p, const char *db_path) {
   }
 
   /* CREATE INDEX proxy_vhost_reverse_per_group_name_idx */
-  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhosts_reverse_per_group_name_idx ON proxy_vhost_reverse_per_group (group_name);";
+  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhost_reverse_per_group_name_idx ON proxy_vhost_reverse_per_group (group_name);";
   res = proxy_db_exec_stmt(p, reverse_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -408,7 +408,7 @@ static int reverse_db_add_schema(pool *p, const char *db_path) {
   }
 
   /* CREATE INDEX proxy_vhost_reverse_per_host_ipaddr_idx */
-  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhosts_reverse_per_host_ipaddr_idx ON proxy_vhost_reverse_per_host (ip_addr);";
+  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhost_reverse_per_host_ipaddr_idx ON proxy_vhost_reverse_per_host (ip_addr);";
   res = proxy_db_exec_stmt(p, reverse_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -498,7 +498,7 @@ static int reverse_truncate_db_tables(pool *p) {
     return -1;
   }
 
-  index_name = "proxy_vhosts_reverse_per_user_name_idx";
+  index_name = "proxy_vhost_reverse_per_user_name_idx";
   res = proxy_db_reindex(p, reverse_dbh, index_name, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -507,7 +507,7 @@ static int reverse_truncate_db_tables(pool *p) {
     return -1;
   }
 
-  index_name = "proxy_vhosts_reverse_per_group_name_idx";
+  index_name = "proxy_vhost_reverse_per_group_name_idx";
   res = proxy_db_reindex(p, reverse_dbh, index_name, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -516,7 +516,7 @@ static int reverse_truncate_db_tables(pool *p) {
     return -1;
   }
 
-  index_name = "proxy_vhosts_reverse_per_host_ipaddr_idx";
+  index_name = "proxy_vhost_reverse_per_host_ipaddr_idx";
   res = proxy_db_reindex(p, reverse_dbh, index_name, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,

--- a/lib/proxy/reverse.c
+++ b/lib/proxy/reverse.c
@@ -2863,8 +2863,11 @@ int proxy_reverse_sess_init(pool *p, const char *tables_dir,
   }
 
   /* Make sure we have our own per-session database handle, per SQLite3
-   * recommendation.
+   * recommendation.  Skip integrity checks and vacuuming, assuming that they
+   * were done on startup.
    */
+  flags |= (PROXY_DB_OPEN_FL_SKIP_INTEGRITY_CHECK|PROXY_DB_OPEN_FL_SKIP_VACUUM);
+
   PRIVS_ROOT
   reverse_dbh = proxy_db_open_with_version(proxy_pool, reverse_db_path,
     PROXY_REVERSE_DB_SCHEMA_NAME, PROXY_REVERSE_DB_SCHEMA_VERSION, flags);

--- a/lib/proxy/reverse.c
+++ b/lib/proxy/reverse.c
@@ -49,7 +49,7 @@ static int reverse_retry_count = PROXY_DEFAULT_RETRY_COUNT;
 static struct proxy_dbh *reverse_dbh = NULL;
 static const char *reverse_db_path = NULL;
 #define PROXY_REVERSE_DB_SCHEMA_NAME		"proxy_reverse"
-#define PROXY_REVERSE_DB_SCHEMA_VERSION		4
+#define PROXY_REVERSE_DB_SCHEMA_VERSION		5
 
 /* Flag that indicates that we should select/connect to the backend server
  * at session init time, i.e. when proxy auth is not required, and we're using
@@ -356,7 +356,7 @@ static int reverse_db_add_schema(pool *p, const char *db_path) {
   }
 
   /* CREATE INDEX proxy_vhost_reverse_per_user_name_idx */
-  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhosts_reverse_per_user_name_idx ON proxy_vhost_reverse_per_user (user_name);";
+  stmt = "CREATE INDEX IF NOT EXISTS proxy_vhost_reverse_per_user_name_idx ON proxy_vhost_reverse_per_user (user_name);";
   res = proxy_db_exec_stmt(p, reverse_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -110,7 +110,7 @@ static int netio_install_ctrl(void);
 static int netio_install_data(void);
 
 #define PROXY_TLS_DB_SCHEMA_NAME		"proxy_tls"
-#define PROXY_TLS_DB_SCHEMA_VERSION		2
+#define PROXY_TLS_DB_SCHEMA_VERSION		3
 
 /* Indices for data stashed in SSL objects */
 #define PROXY_TLS_IDX_TICKET_KEY		2

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -3478,8 +3478,11 @@ int proxy_tls_sess_init(pool *p, int flags) {
   }
 
   /* Make sure we have our own per-session database handle, per SQLite3
-   * recommendation.
+   * recommendation.  Skip integrity checks and vacuuming, assuming that they
+   * were done on startup.
    */
+  flags |= (PROXY_DB_OPEN_FL_SKIP_INTEGRITY_CHECK|PROXY_DB_OPEN_FL_SKIP_VACUUM);
+
   PRIVS_ROOT
   tls_dbh = proxy_db_open_with_version(proxy_pool, tls_db_path,
     PROXY_TLS_DB_SCHEMA_NAME, PROXY_TLS_DB_SCHEMA_VERSION, flags);

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy TLS implementation
- * Copyright (c) 2015-2016 TJ Saunders
+ * Copyright (c) 2015-2017 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -35,6 +35,7 @@
 extern xaset_t *server_list;
 
 static const char *tls_db_path = NULL;
+static struct proxy_dbh *tls_dbh = NULL;
 static int tls_engine = PROXY_TLS_ENGINE_AUTO;
 static unsigned long tls_opts = 0UL;
 static int tls_need_data_prot = TRUE;
@@ -1371,8 +1372,8 @@ static int tls_db_add_sess(pool *p, const char *key, SSL_SESSION *sess) {
   /* We use INSERT OR REPLACE here to get upsert semantics; we only want/
    * need one cached SSL session per URI.
    */
-  stmt = "INSERT OR REPLACE INTO " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_sessions (vhost_id, backend_uri, session) VALUES (?, ?, ?);";
-  res = proxy_db_prepare_stmt(p, stmt);
+  stmt = "INSERT OR REPLACE INTO proxy_tls_sessions (vhost_id, backend_uri, session) VALUES (?, ?, ?);";
+  res = proxy_db_prepare_stmt(p, tls_dbh, stmt);
   if (res < 0) {
     xerrno = errno;
 
@@ -1382,7 +1383,7 @@ static int tls_db_add_sess(pool *p, const char *key, SSL_SESSION *sess) {
   }
 
   vhost_id = main_server->sid;
-  res = proxy_db_bind_stmt(p, stmt, 1, PROXY_DB_BIND_TYPE_INT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 1, PROXY_DB_BIND_TYPE_INT,
     (void *) &vhost_id);
   if (res < 0) {
     xerrno = errno;
@@ -1392,7 +1393,7 @@ static int tls_db_add_sess(pool *p, const char *key, SSL_SESSION *sess) {
     return -1;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
     (void *) key);
   if (res < 0) {
     xerrno = errno;
@@ -1402,7 +1403,7 @@ static int tls_db_add_sess(pool *p, const char *key, SSL_SESSION *sess) {
     return -1;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 3, PROXY_DB_BIND_TYPE_TEXT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 3, PROXY_DB_BIND_TYPE_TEXT,
     (void *) data);
   if (res < 0) {
     xerrno = errno;
@@ -1412,7 +1413,7 @@ static int tls_db_add_sess(pool *p, const char *key, SSL_SESSION *sess) {
     return -1;
   }
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, tls_dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr ? errstr : strerror(errno));
@@ -1433,26 +1434,26 @@ static int tls_db_remove_sess(pool *p, const char *key) {
   const char *stmt, *errstr = NULL;
   array_header *results;
 
-  stmt = "DELETE FROM " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_sessions WHERE vhost_id = ? AND backend_uri = ?;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  stmt = "DELETE FROM proxy_tls_sessions WHERE vhost_id = ? AND backend_uri = ?;";
+  res = proxy_db_prepare_stmt(p, tls_dbh, stmt);
   if (res < 0) {
     return -1;
   }
 
   vhost_id = main_server->sid;
-  res = proxy_db_bind_stmt(p, stmt, 1, PROXY_DB_BIND_TYPE_INT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 1, PROXY_DB_BIND_TYPE_INT,
     (void *) &vhost_id);
   if (res < 0) {
     return -1;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
     (void *) key);
   if (res < 0) {
     return -1;
   }
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, tls_dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr ? errstr : strerror(errno));
@@ -1474,27 +1475,26 @@ static SSL_SESSION *tls_db_get_sess(pool *p, const char *key) {
   long sess_age;
   time_t now;
 
-  stmt = "SELECT session FROM " PROXY_TLS_DB_SCHEMA_NAME
-    ".proxy_tls_sessions WHERE vhost_id = ? AND backend_uri = ?;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  stmt = "SELECT session FROM proxy_tls_sessions WHERE vhost_id = ? AND backend_uri = ?;";
+  res = proxy_db_prepare_stmt(p, tls_dbh, stmt);
   if (res < 0) {
     return NULL;
   }
 
   vhost_id = main_server->sid;
-  res = proxy_db_bind_stmt(p, stmt, 1, PROXY_DB_BIND_TYPE_INT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 1, PROXY_DB_BIND_TYPE_INT,
     (void *) &vhost_id);
   if (res < 0) {
     return NULL;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
     (void *) key);
   if (res < 0) {
     return NULL;
   }
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, tls_dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr ? errstr : strerror(errno));
@@ -1545,14 +1545,13 @@ static int tls_db_get_cached_sess_count(pool *p) {
   const char *stmt, *errstr = NULL;
   array_header *results;
   
-  stmt = "SELECT COUNT(*) FROM " PROXY_TLS_DB_SCHEMA_NAME
-    ".proxy_tls_sessions;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  stmt = "SELECT COUNT(*) FROM proxy_tls_sessions;";
+  res = proxy_db_prepare_stmt(p, tls_dbh, stmt);
   if (res < 0) {
     return -1;
   }
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, tls_dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr ? errstr : strerror(errno));
@@ -2635,13 +2634,13 @@ static int tls_db_add_schema(pool *p, const char *db_path) {
   int res;
   const char *stmt, *errstr = NULL;
 
-  /* CREATE TABLE proxy_tls.proxy_tls_vhosts (
+  /* CREATE TABLE proxy_tls_vhosts (
    *   vhost_id INTEGER NOT NULL PRIMARY KEY,
    *   vhost_name TEXT NOT NULL
    * );
    */
-  stmt = "CREATE TABLE IF NOT EXISTS " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_vhosts (vhost_id INTEGER NOT NULL PRIMARY KEY, vhost_name TEXT NOT NULL);";
-  res = proxy_db_exec_stmt(p, stmt, &errstr);
+  stmt = "CREATE TABLE IF NOT EXISTS proxy_tls_vhosts (vhost_id INTEGER NOT NULL PRIMARY KEY, vhost_name TEXT NOT NULL);";
+  res = proxy_db_exec_stmt(p, tls_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr);
@@ -2649,15 +2648,15 @@ static int tls_db_add_schema(pool *p, const char *db_path) {
     return -1;
   }
 
-  /* CREATE TABLE proxy_tls.proxy_tls_sessions (
+  /* CREATE TABLE proxy_tls_sessions (
    *   backend_uri STRING NOT NULL PRIMARY KEY,
    *   vhost_id INTEGER NOT NULL,
    *   session TEXT NOT NULL,
    *   FOREIGN KEY (vhost_id) REFERENCES proxy_tls_vhosts (vhost_id)
    * );
    */
-  stmt = "CREATE TABLE IF NOT EXISTS " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_sessions (backend_uri STRING NOT NULL PRIMARY KEY, vhost_id INTEGER NOT NULL, session TEXT NOT NULL, FOREIGN KEY (vhost_id) REFERENCES proxy_tls_hosts (vhost_id));";
-  res = proxy_db_exec_stmt(p, stmt, &errstr);
+  stmt = "CREATE TABLE IF NOT EXISTS proxy_tls_sessions (backend_uri STRING NOT NULL PRIMARY KEY, vhost_id INTEGER NOT NULL, session TEXT NOT NULL, FOREIGN KEY (vhost_id) REFERENCES proxy_tls_hosts (vhost_id));";
+  res = proxy_db_exec_stmt(p, tls_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr);
@@ -2674,8 +2673,8 @@ static int tls_truncate_db_tables(pool *p) {
   int res;
   const char *stmt, *errstr = NULL;
 
-  stmt = "DELETE FROM " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_vhosts;";
-  res = proxy_db_exec_stmt(p, stmt, &errstr);
+  stmt = "DELETE FROM proxy_tls_vhosts;";
+  res = proxy_db_exec_stmt(p, tls_dbh, stmt, &errstr);
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr);
@@ -2692,8 +2691,8 @@ static int tls_db_add_vhost(pool *p, server_rec *s) {
   const char *stmt, *errstr = NULL;
   array_header *results;
 
-  stmt = "INSERT INTO " PROXY_TLS_DB_SCHEMA_NAME ".proxy_tls_vhosts (vhost_id, vhost_name) VALUES (?, ?);";
-  res = proxy_db_prepare_stmt(p, stmt);
+  stmt = "INSERT INTO proxy_tls_vhosts (vhost_id, vhost_name) VALUES (?, ?);";
+  res = proxy_db_prepare_stmt(p, tls_dbh, stmt);
   if (res < 0) {
     xerrno = errno;
     (void) pr_log_debug(DEBUG3, MOD_PROXY_VERSION
@@ -2702,19 +2701,19 @@ static int tls_db_add_vhost(pool *p, server_rec *s) {
     return -1;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 1, PROXY_DB_BIND_TYPE_INT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 1, PROXY_DB_BIND_TYPE_INT,
     (void *) &(s->sid));
   if (res < 0) {
     return -1;
   }
 
-  res = proxy_db_bind_stmt(p, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
+  res = proxy_db_bind_stmt(p, tls_dbh, stmt, 2, PROXY_DB_BIND_TYPE_TEXT,
     (void *) s->ServerName);
   if (res < 0) {
     return -1;
   }
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, tls_dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error executing '%s': %s", stmt, errstr ? errstr : strerror(errno));
@@ -2738,12 +2737,12 @@ static int tls_db_init(pool *p, const char *tables_dir, int flags) {
   tls_db_path = pdircat(p, tables_dir, "proxy-tls.db", NULL);
 
   PRIVS_ROOT
-  res = proxy_db_open_with_version(p, tls_db_path, PROXY_TLS_DB_SCHEMA_NAME,
+  tls_dbh = proxy_db_open_with_version(p, tls_db_path, PROXY_TLS_DB_SCHEMA_NAME,
     PROXY_TLS_DB_SCHEMA_VERSION, flags);
   xerrno = errno;
   PRIVS_RELINQUISH
 
-  if (res < 0) {
+  if (tls_dbh == NULL) {
     (void) pr_log_pri(PR_LOG_NOTICE, MOD_PROXY_VERSION
       ": error opening database '%s' for schema '%s', version %u: %s",
       tls_db_path, PROXY_TLS_DB_SCHEMA_NAME, PROXY_TLS_DB_SCHEMA_VERSION,
@@ -2759,7 +2758,8 @@ static int tls_db_init(pool *p, const char *tables_dir, int flags) {
     (void) pr_log_debug(DEBUG0, MOD_PROXY_VERSION
       ": error creating schema in database '%s' for '%s': %s", tls_db_path,
       PROXY_TLS_DB_SCHEMA_NAME, strerror(xerrno));
-    (void) proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME);
+    (void) proxy_db_close(p, tls_dbh);
+    tls_dbh = NULL;
     tls_db_path = NULL;
     errno = xerrno;
     return -1;
@@ -2768,7 +2768,8 @@ static int tls_db_init(pool *p, const char *tables_dir, int flags) {
   res = tls_truncate_db_tables(p);
   if (res < 0) {
     xerrno = errno;
-    (void) proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME);
+    (void) proxy_db_close(p, tls_dbh);
+    tls_dbh = NULL;
     tls_db_path = NULL;
     errno = xerrno;
     return -1;
@@ -2781,12 +2782,16 @@ static int tls_db_init(pool *p, const char *tables_dir, int flags) {
       (void) pr_log_debug(DEBUG0, MOD_PROXY_VERSION
         ": error adding database entry for server '%s' in '%s': %s",
         s->ServerName, PROXY_TLS_DB_SCHEMA_NAME, strerror(xerrno));
-      (void) proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME);
+      (void) proxy_db_close(p, tls_dbh);
+      tls_dbh = NULL;
       tls_db_path = NULL;
       errno = xerrno;
       return -1;
     }
   }
+
+  (void) proxy_db_close(p, tls_dbh);
+  tls_dbh = NULL;
 
   return 0;
 }
@@ -2869,10 +2874,14 @@ int proxy_tls_free(pool *p) {
     ssl_ctx = NULL;
   }
 
-  if (proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME) < 0) {
-    (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
-      "error detaching database with schema '%s': %s",
-      PROXY_TLS_DB_SCHEMA_NAME, strerror(errno));
+  if (tls_dbh != NULL) {
+    if (proxy_db_close(p, tls_dbh) < 0) {
+      (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
+        "error closing %s database: %s", PROXY_TLS_DB_SCHEMA_NAME,
+        strerror(errno));
+    }
+
+    tls_dbh = NULL;
   }
 #endif /* PR_USE_OPENSSL */
 
@@ -3472,12 +3481,12 @@ int proxy_tls_sess_init(pool *p, int flags) {
    * recommendation.
    */
   PRIVS_ROOT
-  res = proxy_db_open_with_version(proxy_pool, tls_db_path,
+  tls_dbh = proxy_db_open_with_version(proxy_pool, tls_db_path,
     PROXY_TLS_DB_SCHEMA_NAME, PROXY_TLS_DB_SCHEMA_VERSION, flags);
   xerrno = errno;
   PRIVS_RELINQUISH
 
-  if (res < 0) {
+  if (tls_dbh == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error opening database '%s' for schema '%s', version %u: %s",
       tls_db_path, PROXY_TLS_DB_SCHEMA_NAME, PROXY_TLS_DB_SCHEMA_VERSION,
@@ -3751,10 +3760,10 @@ int proxy_tls_sess_init(pool *p, int flags) {
    */
   c = find_config(main_server->conf, CONF_PARAM, "TLSEngine", FALSE);
   if (c != NULL) {
-    int tls_engine;
+    int engine;
 
-    tls_engine = *((int *) c->argv[0]);
-    if (tls_engine == TRUE) {
+    engine = *((int *) c->argv[0]);
+    if (engine == TRUE) {
       tls_required_on_frontend_data = TRUE;
     }
   }
@@ -3798,7 +3807,8 @@ int proxy_tls_sess_free(pool *p) {
     tls_psk_used = FALSE;
 # endif /* PSK support */
 
-    proxy_db_close(p, PROXY_TLS_DB_SCHEMA_NAME);
+    proxy_db_close(p, tls_dbh);
+    tls_dbh = NULL;
 
     if (ssl_ctx != NULL) {
       if (init_ssl_ctx() < 0) {

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -879,9 +879,11 @@ MODRET set_proxyreverseservers(cmd_rec *cmd) {
           CONF_ERROR(cmd, pstrcat(cmd->tmp_pool,
             "no usable URLs found in file '", path, NULL));
         }
-      }
 
-      uri = cmd->argv[1];
+      } else {
+        /* Only provide a URI for dynamic lookup, e.g. per-user/group/etc. */
+        uri = cmd->argv[1];
+      }
 
     } else if (strncmp(cmd->argv[1], "sql:/", 5) == 0) {
 

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -553,7 +553,7 @@ START_TEST (db_reindex_test) {
     strerror(errno), errno);
 
   index_name = "test_idx";
-  res = proxy_db_reindex(p, dbh, index_name, NULL);
+  res = proxy_db_reindex(p, dbh, index_name, &errstr);
   fail_unless(res < 0, "Failed to handle invalid index");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -81,23 +81,29 @@ END_TEST
 
 START_TEST (db_open_test) {
   int res;
-  const char *table_path;
+  const char *table_path, *schema_name;
   struct proxy_dbh *dbh;
 
-  dbh = proxy_db_open(NULL, NULL);
+  dbh = proxy_db_open(NULL, NULL, NULL);
   fail_unless(dbh == NULL, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
-  dbh = proxy_db_open(p, NULL);
+  dbh = proxy_db_open(p, NULL, NULL);
   fail_unless(dbh == NULL, "Failed to handle null table path");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
+  schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, NULL);
+  fail_unless(dbh == NULL, "Failed to handle null schema name");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+    strerror(errno), errno);
+
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -187,7 +193,7 @@ END_TEST
 
 START_TEST (db_exec_stmt_test) {
   int res;
-  const char *table_path, *stmt, *errstr;
+  const char *table_path, *schema_name, *stmt, *errstr;
   struct proxy_dbh *dbh;
 
   res = proxy_db_exec_stmt(NULL, NULL, NULL, NULL);
@@ -202,8 +208,9 @@ START_TEST (db_exec_stmt_test) {
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
+  schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -256,7 +263,7 @@ START_TEST (db_prepare_stmt_test) {
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -317,7 +324,7 @@ START_TEST (db_finish_stmt_test) {
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -377,7 +384,7 @@ START_TEST (db_bind_stmt_test) {
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -483,7 +490,7 @@ START_TEST (db_exec_prepared_stmt_test) {
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
@@ -536,7 +543,7 @@ START_TEST (db_reindex_test) {
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  dbh = proxy_db_open(p, table_path);
+  dbh = proxy_db_open(p, table_path, schema_name);
   fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -234,11 +234,11 @@ START_TEST (db_exec_stmt_test) {
 END_TEST
 
 static int create_table(pool *stmt_pool, struct proxy_dbh *dbh,
-    const char *schema_name, const char *table_name) {
+    const char *table_name) {
   int res;
   const char *stmt, *errstr = NULL;
 
-  stmt = pstrcat(stmt_pool, "CREATE TABLE ", schema_name, ".", table_name,
+  stmt = pstrcat(stmt_pool, "CREATE TABLE ", table_name,
     " (id INTEGER, name TEXT);", NULL);
   res = proxy_db_exec_stmt(stmt_pool, dbh, stmt, &errstr);
   return res;
@@ -278,7 +278,7 @@ START_TEST (db_prepare_stmt_test) {
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = create_table(p, dbh, schema_name, "foo");
+  res = create_table(p, dbh, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
@@ -290,7 +290,7 @@ START_TEST (db_prepare_stmt_test) {
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  res = create_table(p, dbh, schema_name, "bar");
+  res = create_table(p, dbh, "bar");
   fail_unless(res == 0, "Failed to create table 'bar': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM bar;";
@@ -339,7 +339,7 @@ START_TEST (db_finish_stmt_test) {
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
-  res = create_table(p, dbh, schema_name, "foo");
+  res = create_table(p, dbh, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, stmt);
@@ -406,7 +406,7 @@ START_TEST (db_bind_stmt_test) {
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
-  res = create_table(p, dbh, schema_name, "foo");
+  res = create_table(p, dbh, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
@@ -505,7 +505,7 @@ START_TEST (db_exec_prepared_stmt_test) {
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
-  res = create_table(p, dbh, schema_name, "foo");
+  res = create_table(p, dbh, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, stmt);

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -554,11 +554,6 @@ START_TEST (db_reindex_test) {
 
   index_name = "test_idx";
   res = proxy_db_reindex(p, dbh, index_name, NULL);
-  fail_unless(res < 0, "Failed to handle invalid index name");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
-    strerror(errno), errno);
-
-  res = proxy_db_reindex(p, dbh, index_name, &errstr);
   fail_unless(res < 0, "Failed to handle invalid index");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2017 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,85 +68,54 @@ START_TEST (db_close_test) {
   int res;
 
   res = proxy_db_close(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  fail_unless(res < 0, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = proxy_db_close(p, NULL);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  fail_unless(res < 0, "Failed to handle null dbh");
+  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+    strerror(errno), errno);
 }
 END_TEST
 
 START_TEST (db_open_test) {
   int res;
-  const char *table_path, *schema_name;
+  const char *table_path;
+  struct proxy_dbh *dbh;
 
-  res = proxy_db_open(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  dbh = proxy_db_open(NULL, NULL);
+  fail_unless(dbh == NULL, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
-  res = proxy_db_open(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null table path");
+  dbh = proxy_db_open(p, NULL);
+  fail_unless(dbh == NULL, "Failed to handle null table path");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
 
-  res = proxy_db_open(p, table_path, NULL);
-  fail_unless(res < 0, "Failed to handle null schema name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
-    strerror(errno), errno);
-
-  schema_name = "proxy_test";
-  res = proxy_db_open(p, "/foo/bar/baz/quxx/quzz.db", schema_name);
-  fail_unless(res < 0, "Failed to handle null schema name");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
-    strerror(errno), errno);
-
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
-
-  res = proxy_db_close(p, schema_name);
-  fail_unless(res == 0, "Failed to detach schema '%s': %s", schema_name,
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
-  res = proxy_db_close(p, schema_name);
-  fail_unless(res < 0, "Unexpectedly detached schema '%s'", schema_name);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
-    strerror(errno), errno);
-
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close table '%s': %s", table_path,
     strerror(errno));
-
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name);
-
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res < 0, "Re-opened table '%s', schema '%s' unexpectedly",
-    table_path, schema_name);
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
-    strerror(errno), errno);
-
-  res = proxy_db_close(p, NULL);
-  fail_unless(res == 0, "Failed to close table '%s': %s", table_path,
-    strerror(errno));
-
   (void) unlink(db_test_table);
 }
 END_TEST
 
 START_TEST (db_open_with_version_test) {
   int res, flags = 0;
+  struct proxy_dbh *dbh;
   const char *table_path, *schema_name;
   unsigned int schema_version;
 
-  res = proxy_db_open_with_version(NULL, NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  dbh = proxy_db_open_with_version(NULL, NULL, NULL, 0, 0);
+  fail_unless(dbh == NULL, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
@@ -161,59 +130,55 @@ START_TEST (db_open_with_version_test) {
   }
 
   mark_point();
-  res = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
+  dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(res == 0,
+  fail_unless(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   mark_point();
   schema_version = 76;
   flags |= PROXY_DB_OPEN_FL_ERROR_ON_SCHEMA_VERSION_SKEW;
-  res = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
+  dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(res < 0, "Opened table with version skew unexpectedly");
+  fail_unless(dbh == NULL, "Opened table with version skew unexpectedly");
   fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
-  res = proxy_db_close(p, NULL);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
-
   mark_point();
   flags &= ~PROXY_DB_OPEN_FL_ERROR_ON_SCHEMA_VERSION_SKEW;
-  res = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
+  dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(res == 0,
+  fail_unless(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   mark_point();
   schema_version = 76;
-  res = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
+  dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(res == 0,
+  fail_unless(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
-  res = proxy_db_close(p, schema_name);
-  fail_unless(res == 0, "Failed to detach schema '%s': %s", schema_name,
-    strerror(errno));
+  res = proxy_db_close(p, dbh);
+  fail_unless(res == 0, "Failed to close databas: %s", strerror(errno));
 
   mark_point();
   schema_version = 99;
-  res = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
+  dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(res == 0,
+  fail_unless(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
@@ -222,111 +187,111 @@ END_TEST
 
 START_TEST (db_exec_stmt_test) {
   int res;
-  const char *table_path, *schema_name, *stmt, *errstr;
+  const char *table_path, *stmt, *errstr;
+  struct proxy_dbh *dbh;
 
-  res = proxy_db_exec_stmt(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  res = proxy_db_exec_stmt(NULL, NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_exec_stmt(p, NULL, NULL);
+  res = proxy_db_exec_stmt(p, NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null dbh");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
+
+  (void) unlink(db_test_table);
+  table_path = db_test_table;
+
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+    strerror(errno));
+
+  res = proxy_db_exec_stmt(p, dbh, NULL, NULL);
   fail_unless(res < 0, "Failed to handle null statement");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo;";
   errstr = NULL;
-  res = proxy_db_exec_stmt(p, stmt, &errstr);
-  fail_unless(res < 0, "Failed to handle missing database handle");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
-    strerror(errno), errno);
-
-  (void) unlink(db_test_table);
-  table_path = db_test_table;
-  schema_name = "proxy_test";
-
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
-
-  res = proxy_db_exec_stmt(p, stmt, &errstr);
+  res = proxy_db_exec_stmt(p, dbh, stmt, &errstr);
   fail_unless(res < 0, "Failed to execute statement '%s'", stmt);
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
 END_TEST
 
-static int create_table(pool *stmt_pool, const char *schema_name,
-    const char *table_name) {
+static int create_table(pool *stmt_pool, struct proxy_dbh *dbh,
+    const char *schema_name, const char *table_name) {
   int res;
   const char *stmt, *errstr = NULL;
 
   stmt = pstrcat(stmt_pool, "CREATE TABLE ", schema_name, ".", table_name,
     " (id INTEGER, name TEXT);", NULL);
-  res = proxy_db_exec_stmt(stmt_pool, stmt, &errstr);
+  res = proxy_db_exec_stmt(stmt_pool, dbh, stmt, &errstr);
   return res;
 }
 
 START_TEST (db_prepare_stmt_test) {
   int res;
   const char *table_path, *schema_name, *stmt;
+  struct proxy_dbh *dbh;
 
-  res = proxy_db_prepare_stmt(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  res = proxy_db_prepare_stmt(NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_prepare_stmt(p, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
+  res = proxy_db_prepare_stmt(p, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null dbh");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  stmt = "SELECT COUNT(*) FROM table;";
-  res = proxy_db_prepare_stmt(p, stmt);
-  fail_unless(res < 0, "Failed to handle missing database handle");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+    strerror(errno));
+
+  res = proxy_db_prepare_stmt(p, dbh, NULL);
+  fail_unless(res < 0, "Failed to handle null statement");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
 
   stmt = "foo bar baz?";
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res < 0, "Prepared invalid statement '%s' unexpectedly", stmt);
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = create_table(p, schema_name, "foo");
+  res = create_table(p, dbh, schema_name, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  res = create_table(p, schema_name, "bar");
+  res = create_table(p, dbh, schema_name, "bar");
   fail_unless(res == 0, "Failed to create table 'bar': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM bar;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
@@ -336,48 +301,54 @@ END_TEST
 START_TEST (db_finish_stmt_test) {
   int res;
   const char *table_path, *schema_name, *stmt;
+  struct proxy_dbh *dbh;
 
-  res = proxy_db_finish_stmt(NULL, NULL);
+  res = proxy_db_finish_stmt(NULL, NULL, NULL);
   fail_unless(res < 0, "Failed to handle null arguments");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_finish_stmt(p, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
+  res = proxy_db_finish_stmt(p, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null dbh");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  stmt = "SELECT COUNT(*) FROM foo";
-  res = proxy_db_finish_stmt(p, stmt);
-  fail_unless(res < 0, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
-
-  res = create_table(p, schema_name, "foo");
-  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
-
-  res = proxy_db_prepare_stmt(p, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
-  res = proxy_db_finish_stmt(p, stmt);
-  fail_unless(res == 0, "Failed to finish statement '%s': %s", stmt,
-    strerror(errno));
+  res = proxy_db_finish_stmt(p, dbh, NULL);
+  fail_unless(res < 0, "Failed to handle null statement");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
 
-  res = proxy_db_finish_stmt(p, stmt);
+  stmt = "SELECT COUNT(*) FROM foo";
+  res = proxy_db_finish_stmt(p, dbh, stmt);
   fail_unless(res < 0, "Failed to handle unprepared statement");
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
-  res = proxy_db_close(p, NULL);
+  res = create_table(p, dbh, schema_name, "foo");
+  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
+
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
+  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+    strerror(errno));
+
+  res = proxy_db_finish_stmt(p, dbh, stmt);
+  fail_unless(res == 0, "Failed to finish statement '%s': %s", stmt,
+    strerror(errno));
+
+  res = proxy_db_finish_stmt(p, dbh, stmt);
+  fail_unless(res < 0, "Failed to handle unprepared statement");
+  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+    strerror(errno), errno);
+
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
@@ -387,98 +358,107 @@ END_TEST
 START_TEST (db_bind_stmt_test) {
   int res;
   const char *table_path, *schema_name, *stmt;
+  struct proxy_dbh *dbh;
   int idx, int_val;
   long long_val;
   char *text_val;
 
-  res = proxy_db_bind_stmt(NULL, NULL, -1, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  res = proxy_db_bind_stmt(NULL, NULL, NULL, -1, -1, NULL);
+  fail_unless(res < 0, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_bind_stmt(p, NULL, -1, -1, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
+  res = proxy_db_bind_stmt(p, NULL, NULL, -1, -1, NULL);
+  fail_unless(res < 0, "Failed to handle null dbh");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  stmt = "SELECT COUNT(*) FROM table";
-  idx = -1;
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
-  fail_unless(res < 0, "Failed to handle invalid index %d", idx);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  idx = 1;
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
-  fail_unless(res < 0, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+    strerror(errno));
 
-  res = create_table(p, schema_name, "foo");
+  res = proxy_db_bind_stmt(p, dbh, NULL, -1, -1, NULL);
+  fail_unless(res < 0, "Failed to handle null statement");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
+
+  stmt = "SELECT COUNT(*) FROM table";
+  idx = -1;
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
+  fail_unless(res < 0, "Failed to handle invalid index %d", idx);
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
+
+  idx = 1;
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
+  fail_unless(res < 0, "Failed to handle unprepared statement");
+  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+    strerror(errno), errno);
+
+  res = create_table(p, dbh, schema_name, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL);
   fail_unless(res < 0, "Failed to handle missing INT value");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   int_val = 7;
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val);
   fail_unless(res < 0, "Failed to handle invalid index value");
   fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_LONG, NULL);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_LONG, NULL);
   fail_unless(res < 0, "Failed to handle missing LONG value");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   long_val = 7;
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_LONG, &long_val);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_LONG,
+    &long_val);
   fail_unless(res < 0, "Failed to handle invalid index value");
   fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_TEXT, NULL);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_TEXT, NULL);
   fail_unless(res < 0, "Failed to handle missing TEXT value");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   text_val = "testing";
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_TEXT, text_val);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_TEXT,
+    text_val);
   fail_unless(res < 0, "Failed to handle invalid index value");
   fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_NULL, NULL);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_NULL, NULL);
   fail_unless(res < 0, "Failed to handle invalid NULL value");
   fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo WHERE id = ?;";
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   int_val = 7;
-  res = proxy_db_bind_stmt(p, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val);
+  res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val);
   fail_unless(res == 0, "Failed to bind INT value: %s", strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+
   (void) unlink(db_test_table);
 }
 END_TEST
@@ -487,49 +467,50 @@ START_TEST (db_exec_prepared_stmt_test) {
   int res;
   array_header *results;
   const char *table_path, *schema_name, *stmt, *errstr = NULL;
+  struct proxy_dbh *dbh;
 
-  results = proxy_db_exec_prepared_stmt(NULL, NULL, NULL);
-  fail_unless(results == NULL, "Failed to handle null arguments");
+  results = proxy_db_exec_prepared_stmt(NULL, NULL, NULL, NULL);
+  fail_unless(results == NULL, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  results = proxy_db_exec_prepared_stmt(p, NULL, NULL);
-  fail_unless(results == NULL, "Failed to handle null statement");
+  results = proxy_db_exec_prepared_stmt(p, NULL, NULL, NULL);
+  fail_unless(results == NULL, "Failed to handle null dbh");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  stmt = "SELECT COUNT(*) FROM foo;";
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
-  fail_unless(results == NULL, "Failed to handle unprepared statement");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+    strerror(errno));
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, dbh, NULL, NULL);
+  fail_unless(results == NULL, "Failed to handle null statement");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
+
+  stmt = "SELECT COUNT(*) FROM foo;";
+  results = proxy_db_exec_prepared_stmt(p, dbh, stmt, &errstr);
   fail_unless(results == NULL, "Failed to handle unprepared statement");
   fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
-  res = create_table(p, schema_name, "foo");
+  res = create_table(p, dbh, schema_name, "foo");
   fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
-  res = proxy_db_prepare_stmt(p, stmt);
+  res = proxy_db_prepare_stmt(p, dbh, stmt);
   fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
-  results = proxy_db_exec_prepared_stmt(p, stmt, &errstr);
+  results = proxy_db_exec_prepared_stmt(p, dbh, stmt, &errstr);
   fail_unless(results != NULL,
     "Failed to execute prepared statement '%s': %s (%s)", stmt, errstr,
     strerror(errno));
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
@@ -539,38 +520,44 @@ END_TEST
 START_TEST (db_reindex_test) {
   int res;
   const char *table_path, *schema_name, *index_name, *errstr = NULL;
+  struct proxy_dbh *dbh;
 
-  res = proxy_db_reindex(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
+  res = proxy_db_reindex(NULL, NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null pool");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
-  res = proxy_db_reindex(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null index name");
+  res = proxy_db_reindex(p, NULL, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null dbh");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
-    strerror(errno), errno);
-
-  index_name = "test_idx";
-  res = proxy_db_reindex(p, index_name, NULL);
-  fail_unless(res < 0, "Failed to handle invalid index name");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
   table_path = db_test_table;
   schema_name = "proxy_test";
 
-  res = proxy_db_open(p, table_path, schema_name);
-  fail_unless(res == 0, "Failed to open table '%s', schema '%s': %s",
-    table_path, schema_name, strerror(errno));
+  dbh = proxy_db_open(p, table_path);
+  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+    strerror(errno));
 
-  res = proxy_db_reindex(p, index_name, &errstr);
+  res = proxy_db_reindex(p, dbh, NULL, NULL);
+  fail_unless(res < 0, "Failed to handle null index name");
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+    strerror(errno), errno);
+
+  index_name = "test_idx";
+  res = proxy_db_reindex(p, dbh, index_name, NULL);
+  fail_unless(res < 0, "Failed to handle invalid index name");
+  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+    strerror(errno), errno);
+
+  res = proxy_db_reindex(p, dbh, index_name, &errstr);
   fail_unless(res < 0, "Failed to handle invalid index");
   fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
   fail_unless(errstr != NULL, "Failed to provide error string");
 
-  res = proxy_db_close(p, NULL);
+  res = proxy_db_close(p, dbh);
   fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);

--- a/t/api/reverse.c
+++ b/t/api/reverse.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2013-2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2013-2017 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -224,7 +224,7 @@ START_TEST (reverse_sess_init_test) {
   mark_point();
   res = proxy_reverse_sess_init(NULL, NULL, NULL, flags);
   fail_unless(res < 0, "Unexpectedly init'd Reverse API session resources");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();


### PR DESCRIPTION
…r own

handles, rather than having the API assume a single handle.  This avoids
the whole ATTACH/DETACH database, which I think was clouding the "database is
locked" issue.  This also makes the design conceptually simpler, at least to
me.