### PR TITLE
Issue #123: Fix compilation when using OpenSSL-1.1.x.

### DIFF
--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy
- * Copyright (c) 2012-2017 TJ Saunders
+ * Copyright (c) 2012-2018 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -1485,7 +1485,7 @@ MODRET set_proxytlspresharedkey(cmd_rec *cmd) {
 # else
   pr_log_debug(DEBUG0,
     "%s is not supported by this build/version of OpenSSL, ignoring",
-    cmd->argv[0]);
+    (char *) cmd->argv[0]);
 # endif /* PSK support */
   return PR_HANDLED(cmd);
 #else

--- a/t/Makefile.in
+++ b/t/Makefile.in
@@ -41,6 +41,7 @@ TEST_API_DEPS=\
   $(top_srcdir)/src/support.o \
   $(top_srcdir)/src/json.o \
   $(top_srcdir)/src/redis.o \
+  $(top_srcdir)/src/error.o \
   $(module_srcdir)/lib/proxy/random.o \
   $(module_srcdir)/lib/proxy/db.o \
   $(module_srcdir)/lib/proxy/uri.o \

--- a/t/api/stubs.c
+++ b/t/api/stubs.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy API testsuite
- * Copyright (c) 2012-2017 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2012-2018 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -244,6 +244,9 @@ void pr_log_pri(int prio, const char *fmt, ...) {
 
     fprintf(stderr, "\n");
   }
+}
+
+void pr_log_stacktrace(int fd, const char *name) {
 }
 
 int pr_log_writefile(int fd, const char *name, const char *fmt, ...) {

--- a/t/api/stubs.c
+++ b/t/api/stubs.c
@@ -272,6 +272,10 @@ int pr_scoreboard_entry_update(pid_t pid, ...) {
 void pr_session_disconnect(module *m, int reason_code, const char *details) {
 }
 
+const char *pr_session_get_protocol(int flags) {
+  return "ftp";
+}
+
 void pr_signals_handle(void) {
 }
 


### PR DESCRIPTION
This also ensures that mod_proxy can be built using LibreSSL as well.