### PR TITLE
Issue #129: Clean up `.lo` objects in the `lib/proxy/reverse/` and

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -81,7 +81,7 @@ install-misc:
 	$(INSTALL) -o $(INSTALL_USER) -g $(INSTALL_GROUP) -m 0644 cacerts.pem $(DESTDIR)$(sysconfdir)/cacerts.pem
 
 clean:
-	$(LIBTOOL) --mode=clean $(RM) $(MODULE_NAME).a $(MODULE_NAME).la *.o *.lo .libs/*.o lib/proxy/*.o lib/proxy/*.lo lib/proxy/ftp/*.o lib/proxy/ftp/*.lo
+	$(LIBTOOL) --mode=clean $(RM) $(MODULE_NAME).a $(MODULE_NAME).la *.o *.lo .libs/*.o lib/proxy/*.o lib/proxy/*.lo lib/proxy/ftp/*.o lib/proxy/ftp/*.lo lib/proxy/reverse/*.lo lib/proxy/tls/*.lo
 
 # Run the API tests
 check:


### PR DESCRIPTION
`lib/proxy/tls` directories, too.