### PR TITLE
Return auth error instead of selecting last used backend from Redis

### DIFF
--- a/lib/proxy/reverse/redis.c
+++ b/lib/proxy/reverse/redis.c
@@ -116,6 +116,11 @@ static array_header *redis_get_list_backend_uris(pool *p,
   pool *tmp_pool;
   char *key;
   array_header *backend_uris, *values = NULL, *valueszs = NULL;
+  array_header *backend = NULL;
+
+  backend = proxy_reverse_pername_backends(p, name, TRUE);
+  if (backend == NULL)
+    return NULL;
 
   tmp_pool = make_sub_pool(p);
   key = make_key(tmp_pool, policy, vhost_id, name);
@@ -274,7 +279,7 @@ static long reverse_redis_shuffle_next(pool *p, pr_redis_t *redis,
 
     count = 0;
   }
- 
+
   if (count == 0) {
     res = reverse_redis_shuffle_init(p, redis, vhost_id, redis_backends);
     xerrno = errno;
@@ -985,7 +990,7 @@ static const struct proxy_conn *reverse_redis_policy_next_backend(pool *p,
           pr_netaddr_get_ipstr(session.c->remote_addr));
       }
       break;
- 
+
     default:
       errno = ENOSYS;
       return NULL;
@@ -1115,7 +1120,7 @@ static void *reverse_redis_init(pool *p, const char *tables_path, int flags) {
   }
 
   (void) pr_redis_conn_set_namespace(redis, &proxy_module, redis_prefix,
-    redis_prefixsz); 
+    redis_prefixsz);
   return redis;
 }
 


### PR DESCRIPTION
During heavy DDoS attacks, our backends at the bottom of ProFTPd just get unusable (overloaded) because ProFTPd selects last used backend from Redis instead of returning auth error.

Signed-off-by: Donatas Abraitis <donatas.abraitis@gmail.com>