### PR TITLE
Issue #158: Attempt to address the reported `EINVAL` error, in the RF…

### DIFF
--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -2760,7 +2760,7 @@ MODRET proxy_eprt(cmd_rec *cmd, struct proxy_session *proxy_sess) {
     const char *rfc1918_ipstr;
 
     rfc1918_ipstr = pr_netaddr_get_ipstr(remote_addr);
-    remote_addr = pr_netaddr_dup(cmd->tmp_pool, session.c->remote_addr);
+    remote_addr = pr_netaddr_dup(session.pool, session.c->remote_addr);
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "client sent RFC1918 address '%s' in EPRT command, ignoring it and "
       "using '%s'", rfc1918_ipstr, pr_netaddr_get_ipstr(remote_addr));
@@ -3190,7 +3190,7 @@ MODRET proxy_port(cmd_rec *cmd, struct proxy_session *proxy_sess) {
     const char *rfc1918_ipstr;
 
     rfc1918_ipstr = pr_netaddr_get_ipstr(remote_addr);
-    remote_addr = pr_netaddr_dup(cmd->tmp_pool, session.c->remote_addr);
+    remote_addr = pr_netaddr_dup(session.pool, session.c->remote_addr);
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "client sent RFC1918 address '%s' in PORT command, ignoring it and "
       "using '%s'", rfc1918_ipstr, pr_netaddr_get_ipstr(remote_addr));

--- a/t/api/netio.c
+++ b/t/api/netio.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2020 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -78,7 +78,7 @@ START_TEST (netio_open_test) {
 
   nstrm = proxy_netio_open(p, 77, -1, PR_NETIO_IO_RD);
   fail_unless(nstrm == NULL, "Failed to handle unsupported stream type");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);


### PR DESCRIPTION
…C1918

fallback case, by using the session pool's longer lifetime.