### PR TITLE
For a ProxyReverseConnectPolicy of PerUser or PerGroup, make sure to …

### DIFF
--- a/lib/proxy/reverse/db.c
+++ b/lib/proxy/reverse/db.c
@@ -948,7 +948,8 @@ static const struct proxy_conn *reverse_db_peruser_next(pool *p,
   const struct proxy_conn *pconn = NULL;
 
   pconn = reverse_db_peruser_init(p, dbh, vhost_id, user);
-  if (pconn == NULL) {
+  if (pconn == NULL &&
+      errno != ENOENT) {
     results = reverse_db_peruser_get(p, dbh, vhost_id, user);
     if (results != NULL &&
         results->nelts > 0) {
@@ -1144,7 +1145,8 @@ static const struct proxy_conn *reverse_db_pergroup_next(pool *p,
   const struct proxy_conn *pconn = NULL;
 
   pconn = reverse_db_pergroup_init(p, dbh, vhost_id, group);
-  if (pconn == NULL) {
+  if (pconn == NULL &&
+      errno != ENOENT) {
     results = reverse_db_pergroup_get(p, dbh, vhost_id, group);
     if (results != NULL &&
         results->nelts > 0) {

--- a/lib/proxy/reverse/redis.c
+++ b/lib/proxy/reverse/redis.c
@@ -611,7 +611,8 @@ static const struct proxy_conn *reverse_redis_peruser_next(pool *p,
   const struct proxy_conn *pconn = NULL;
 
   pconn = reverse_redis_peruser_init(p, redis, vhost_id, user);
-  if (pconn == NULL) {
+  if (pconn == NULL &&
+      errno != ENOENT) {
     backend_uris = reverse_redis_peruser_get(p, redis, vhost_id, user);
     if (backend_uris != NULL) {
       char **vals;
@@ -692,7 +693,8 @@ static const struct proxy_conn *reverse_redis_pergroup_next(pool *p,
   const struct proxy_conn *pconn = NULL;
 
   pconn = reverse_redis_pergroup_init(p, redis, vhost_id, group);
-  if (pconn == NULL) {
+  if (pconn == NULL &&
+      errno != ENOENT) {
     backend_uris = reverse_redis_pergroup_get(p, redis, vhost_id, group);
     if (backend_uris != NULL) {
       char **vals;


### PR DESCRIPTION
…properly

handle the case where the given user/group name is not found.