### PR TITLE
Fix off-by-one error in proxy_ftp_msg_fmt_addr

### DIFF
--- a/lib/proxy/ftp/msg.c
+++ b/lib/proxy/ftp/msg.c
@@ -70,7 +70,7 @@ const char *proxy_ftp_msg_fmt_addr(pool *p, const pr_netaddr_t *addr,
   msglen = (6 * 3) + (5 * 1) + 1;
 
   msg = pcalloc(p, msglen);
-  snprintf(msg, msglen-1, "%s,%u,%u", addr_str, (port >> 8) & 255, port & 255);
+  snprintf(msg, msglen, "%s,%u,%u", addr_str, (port >> 8) & 255, port & 255);
 
   return msg;
 }

--- a/t/api/ftp/msg.c
+++ b/t/api/ftp/msg.c
@@ -88,6 +88,16 @@ START_TEST (fmt_addr_test) {
   expected = "127,0,0,1,8,73";
   fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
+
+  addr = pr_netaddr_get_addr(p, "169.254.254.254", NULL);
+  fail_unless(addr != NULL, "Failed to get addr for 169.254.254.254: %s",
+    strerror(errno));
+  res = proxy_ftp_msg_fmt_addr(p, addr, 38550, FALSE);
+  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  expected = "169,254,254,254,150,150";
+  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+    expected, res);
+
 }
 END_TEST
 


### PR DESCRIPTION
snprintf already writes the NULL byte into the string, so by using
`msglen-1` the string will be too short for the "worst case message".
Which is an IP with all 4 octets `>= 100` and `port % 255 >= 100`, which
happens quite often in our case.

Similar to #145 