### PR TITLE
Issue #168: Fix issues with FTPS uploads to backend servers.

### DIFF
--- a/lib/proxy/inet.c
+++ b/lib/proxy/inet.c
@@ -72,14 +72,21 @@ void proxy_inet_close(pool *p, conn_t *conn) {
      * functions for closing, too.
      */
 
+    /* Shutdowns first, then closes. */
     if (conn->instrm != NULL) {
       proxy_netio_shutdown(conn->instrm, 0);
+    }
+
+    if (conn->outstrm != NULL) {
+      proxy_netio_shutdown(conn->outstrm, 1);
+    }
+
+    if (conn->instrm != NULL) {
       proxy_netio_close(conn->instrm);
       conn->instrm = NULL;
     }
 
     if (conn->outstrm != NULL) {
-      proxy_netio_shutdown(conn->outstrm, 1);
       proxy_netio_close(conn->outstrm);
       conn->outstrm = NULL;
     }

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -2504,6 +2504,9 @@ static int get_disabled_protocols(unsigned int supported_protocols) {
 # ifdef SSL_OP_NO_TLSv1_2
   disabled_protocols |= SSL_OP_NO_TLSv1_2;
 # endif
+# ifdef SSL_OP_NO_TLSv1_3
+  disabled_protocols |= SSL_OP_NO_TLSv1_3;
+# endif
 
   /* Now, based on the given bitset of supported protocols, clear the
    * necessary bits.
@@ -3749,7 +3752,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
     case TLSEXT_TYPE_supported_versions: {
       BIO *bio = NULL;
       char *ext_info = NULL;
-      long ext_infolen;
+      long ext_infolen = 0;
 
       /* If we are the server responding, we only indicate the selected
        * protocol version.  Otherwise, we are a client indicating the range
@@ -3819,7 +3822,7 @@ static void tls_tlsext_cb(SSL *ssl, int server, int type,
     case TLSEXT_TYPE_psk_kex_modes: {
       BIO *bio = NULL;
       char *ext_info = NULL;
-      long ext_infolen;
+      long ext_infolen = 0;
 
       extension_name = "PSK KEX modes";
 

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -4432,8 +4432,11 @@ static void proxy_exit_ev(const void *event_data, void *user_data) {
   proxy_sess = (struct proxy_session *) pr_table_get(session.notes,
     "mod_proxy.proxy-session", NULL);
   if (proxy_sess != NULL) {
+    /* proxy_sess->frontend_ctrl_conn is session.c; let the core engine
+     * close that connection.  If we try to close it here via pr_inet_close(),
+     * we risk segfaults due to double-free of the memory, stale pointers, etc.
+     */
     if (proxy_sess->frontend_ctrl_conn != NULL) {
-      pr_inet_close(proxy_sess->pool, proxy_sess->frontend_ctrl_conn);
       proxy_sess->frontend_ctrl_conn = NULL;
     }
 


### PR DESCRIPTION
The problem was that we need to do network shutdowns on both read/write
streams first, and _then_ close those streams.  We were doing a shutdown+close
on the read stream, then on the write stream.  While this works for
downloads/data transfers, with regard to proper TLS session shutdowns, it is
the wrong order of events for uploads.