### PR TITLE
Update the `mod_proxy` unit tests to use the non-deprecated `libcheck…

### DIFF
--- a/t/api/conn.c
+++ b/t/api/conn.c
@@ -58,19 +58,19 @@ START_TEST (conn_create_test) {
   const char *url;
 
   pconn = proxy_conn_create(NULL, NULL, 0);
-  fail_unless(pconn == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(NULL, url, 0);
-  fail_unless(pconn == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   pconn = proxy_conn_create(p, NULL, 0);
-  fail_unless(pconn == NULL, "Failed to handle null URL argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn == NULL, "Failed to handle null URL argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   /* We're already testing URL parsing elsewhere, so we only need to
    * supply well-formed URLs in these tests.
@@ -79,20 +79,20 @@ START_TEST (conn_create_test) {
   mark_point();
   url = "http://127.0.0.1:80";
   pconn = proxy_conn_create(p, url, 0);
-  fail_unless(pconn == NULL, "Failed to handle unsupported protocol/scheme");
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM");
+  ck_assert_msg(pconn == NULL, "Failed to handle unsupported protocol/scheme");
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM");
 
   mark_point();
   url = "ftp://foo.bar.baz";
   pconn = proxy_conn_create(p, url, 0);
-  fail_unless(pconn == NULL, "Failed to handle unresolvable host");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn == NULL, "Failed to handle unresolvable host");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   mark_point();
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   proxy_conn_free(pconn);
 }
@@ -105,18 +105,18 @@ START_TEST (conn_get_addr_test) {
   array_header *other_addrs = NULL;
  
   pconn_addr = proxy_conn_get_addr(NULL, NULL);
-  fail_unless(pconn_addr == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn_addr == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
  
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   pconn_addr = proxy_conn_get_addr(pconn, &other_addrs);
-  fail_if(pconn_addr == NULL, "Failed to get address for pconn");
+  ck_assert_msg(pconn_addr != NULL, "Failed to get address for pconn");
   ipstr = pr_netaddr_get_ipstr(pconn_addr);
-  fail_unless(strcmp(ipstr, "127.0.0.1") == 0,
+  ck_assert_msg(strcmp(ipstr, "127.0.0.1") == 0,
     "Expected IP address '127.0.0.1', got '%s'", ipstr);
 
   proxy_conn_free(pconn);
@@ -128,20 +128,20 @@ START_TEST (conn_get_host_test) {
   const struct proxy_conn *pconn;
 
   host = proxy_conn_get_host(NULL);
-  fail_unless(host == NULL, "Got host from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(host == NULL, "Got host from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   host = proxy_conn_get_host(pconn);
-  fail_unless(host != NULL, "Failed to get host from conn: %s",
+  ck_assert_msg(host != NULL, "Failed to get host from conn: %s",
     strerror(errno));
   expected = "127.0.0.1";
-  fail_unless(strcmp(host, expected) == 0, "Expected host '%s', got '%s'",
+  ck_assert_msg(strcmp(host, expected) == 0, "Expected host '%s', got '%s'",
     expected, host);
 
   proxy_conn_free(pconn);
@@ -154,17 +154,17 @@ START_TEST (conn_get_port_test) {
   const struct proxy_conn *pconn;
 
   port = proxy_conn_get_port(NULL);
-  fail_unless(port < 0, "Got port from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(port < 0, "Got port from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   port = proxy_conn_get_port(pconn);
-  fail_unless(port == 21, "Expected port 21, got %d", port);
+  ck_assert_msg(port == 21, "Expected port 21, got %d", port);
 
   proxy_conn_free(pconn);
 }
@@ -175,18 +175,18 @@ START_TEST (conn_get_hostport_test) {
   const char *hostport, *url;
 
   hostport = proxy_conn_get_hostport(NULL);
-  fail_unless(hostport == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(hostport == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
  
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   hostport = proxy_conn_get_hostport(pconn);
-  fail_if(hostport == NULL, "Failed to get host/port for pconn");
-  fail_unless(strcmp(hostport, "127.0.0.1:21") == 0,
+  ck_assert_msg(hostport != NULL, "Failed to get host/port for pconn");
+  ck_assert_msg(strcmp(hostport, "127.0.0.1:21") == 0,
     "Expected host/port '127.0.0.1:21', got '%s'", hostport);
 
   /* Implicit/assumed ports */
@@ -194,12 +194,12 @@ START_TEST (conn_get_hostport_test) {
 
   url = "ftp://127.0.0.1";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   hostport = proxy_conn_get_hostport(pconn);
-  fail_if(hostport == NULL, "Failed to get host/port for pconn");
-  fail_unless(strcmp(hostport, "127.0.0.1:21") == 0,
+  ck_assert_msg(hostport != NULL, "Failed to get host/port for pconn");
+  ck_assert_msg(strcmp(hostport, "127.0.0.1:21") == 0,
     "Expected host/port '127.0.0.1:21', got '%s'", hostport);
 
   proxy_conn_free(pconn);
@@ -211,17 +211,17 @@ START_TEST (conn_get_uri_test) {
   const char *pconn_url, *url;
 
   pconn_url = proxy_conn_get_uri(NULL);
-  fail_unless(pconn_url == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(pconn_url == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
  
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   pconn_url = proxy_conn_get_uri(pconn);
-  fail_if(pconn_url == NULL, "Failed to get URL for pconn");
-  fail_unless(strcmp(pconn_url, url) == 0,
+  ck_assert_msg(pconn_url != NULL, "Failed to get URL for pconn");
+  ck_assert_msg(strcmp(pconn_url, url) == 0,
     "Expected URL '%s', got '%s'", url, pconn_url);
 
   proxy_conn_free(pconn);
@@ -233,28 +233,28 @@ START_TEST (conn_get_username_test) {
   const struct proxy_conn *pconn;
 
   username = proxy_conn_get_username(NULL);
-  fail_unless(username == NULL, "Got username from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(username == NULL, "Got username from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   username = proxy_conn_get_username(pconn);
-  fail_unless(username == NULL, "Got username unexpectedly");
+  ck_assert_msg(username == NULL, "Got username unexpectedly");
   proxy_conn_free(pconn);
 
   url = "ftp://user:passwd@127.0.0.1:2121";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   username = proxy_conn_get_username(pconn);
-  fail_unless(username != NULL, "Expected username from conn");
+  ck_assert_msg(username != NULL, "Expected username from conn");
   expected = "user";
-  fail_unless(strcmp(username, expected) == 0,
+  ck_assert_msg(strcmp(username, expected) == 0,
     "Expected username '%s', got '%s'", expected, username);
 
   proxy_conn_free(pconn);
@@ -266,40 +266,40 @@ START_TEST (conn_get_password_test) {
   const struct proxy_conn *pconn;
 
   passwd = proxy_conn_get_password(NULL);
-  fail_unless(passwd == NULL, "Got password from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(passwd == NULL, "Got password from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd == NULL, "Got password unexpectedly");
+  ck_assert_msg(passwd == NULL, "Got password unexpectedly");
   proxy_conn_free(pconn);
 
   url = "ftp://user:passwd@127.0.0.1:2121";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd != NULL, "Expected password from conn");
+  ck_assert_msg(passwd != NULL, "Expected password from conn");
   expected = "passwd";
-  fail_unless(strcmp(passwd, expected) == 0,
+  ck_assert_msg(strcmp(passwd, expected) == 0,
     "Expected password '%s', got '%s'", expected, passwd);
   proxy_conn_free(pconn);
 
   url = "ftp://user:@127.0.0.1:2121";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd != NULL, "Expected password from conn");
+  ck_assert_msg(passwd != NULL, "Expected password from conn");
   expected = "";
-  fail_unless(strcmp(passwd, expected) == 0,
+  ck_assert_msg(strcmp(passwd, expected) == 0,
     "Expected password '%s', got '%s'", expected, passwd);
 
   proxy_conn_free(pconn);
@@ -313,102 +313,102 @@ START_TEST (conn_get_tls_test) {
 
   mark_point();
   tls = proxy_conn_get_tls(NULL);
-  fail_unless(tls < 0, "Got TLS from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(tls < 0, "Got TLS from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftp+srv://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftp+txt://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+srv://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+txt://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps://127.0.0.1:990";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_IMPLICIT,
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_IMPLICIT,
     "Expected TLS implicit, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+srv://127.0.0.1:990";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+txt://127.0.0.1:990";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   tls = proxy_conn_get_tls(pconn);
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
   proxy_conn_free(pconn);
 }
 END_TEST
@@ -420,53 +420,53 @@ START_TEST (conn_use_dns_srv_test) {
 
   mark_point();
   use_dns_srv = proxy_conn_use_dns_srv(NULL);
-  fail_unless(use_dns_srv < 0, "Got DNS SRV from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(use_dns_srv < 0, "Got DNS SRV from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   use_dns_srv = proxy_conn_use_dns_srv(pconn);
-  fail_unless(use_dns_srv == FALSE, "Expected DNS SRV = false, got %d",
+  ck_assert_msg(use_dns_srv == FALSE, "Expected DNS SRV = false, got %d",
     use_dns_srv);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftp+srv://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   use_dns_srv = proxy_conn_use_dns_srv(pconn);
-  fail_unless(use_dns_srv == TRUE, "Expected DNS SRV = true, got %d",
+  ck_assert_msg(use_dns_srv == TRUE, "Expected DNS SRV = true, got %d",
     use_dns_srv);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   use_dns_srv = proxy_conn_use_dns_srv(pconn);
-  fail_unless(use_dns_srv == FALSE, "Expected DNS SRV = false, got %d",
+  ck_assert_msg(use_dns_srv == FALSE, "Expected DNS SRV = false, got %d",
     use_dns_srv);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+srv://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   use_dns_srv = proxy_conn_use_dns_srv(pconn);
-  fail_unless(use_dns_srv == TRUE, "Expected DNS SRV = true, got %d",
+  ck_assert_msg(use_dns_srv == TRUE, "Expected DNS SRV = true, got %d",
     use_dns_srv);
   proxy_conn_free(pconn);
 }
@@ -479,53 +479,53 @@ START_TEST (conn_use_dns_txt_test) {
 
   mark_point();
   use_dns_txt = proxy_conn_use_dns_txt(NULL);
-  fail_unless(use_dns_txt < 0, "Got DNS TXT from null pconn unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(use_dns_txt < 0, "Got DNS TXT from null pconn unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   use_dns_txt = proxy_conn_use_dns_txt(pconn);
-  fail_unless(use_dns_txt == FALSE, "Expected DNS TXT = false, got %d",
+  ck_assert_msg(use_dns_txt == FALSE, "Expected DNS TXT = false, got %d",
     use_dns_txt);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftp+txt://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   mark_point();
   use_dns_txt = proxy_conn_use_dns_txt(pconn);
-  fail_unless(use_dns_txt == TRUE, "Expected DNS TXT = true, got %d",
+  ck_assert_msg(use_dns_txt == TRUE, "Expected DNS TXT = true, got %d",
     use_dns_txt);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   use_dns_txt = proxy_conn_use_dns_txt(pconn);
-  fail_unless(use_dns_txt == FALSE, "Expected DNS TXT = false, got %d",
+  ck_assert_msg(use_dns_txt == FALSE, "Expected DNS TXT = false, got %d",
     use_dns_txt);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftps+txt://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   use_dns_txt = proxy_conn_use_dns_txt(pconn);
-  fail_unless(use_dns_txt == TRUE, "Expected DNS TXT = true, got %d",
+  ck_assert_msg(use_dns_txt == TRUE, "Expected DNS TXT = true, got %d",
     use_dns_txt);
   proxy_conn_free(pconn);
 }
@@ -538,42 +538,42 @@ START_TEST (conn_get_dns_ttl_test) {
 
   mark_point();
   res = proxy_conn_get_dns_ttl(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   url = "ftp://www.google.com";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   res = proxy_conn_get_dns_ttl(pconn);
-  fail_unless(res < 0, "Failed to handle non-TTL URL");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle non-TTL URL");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   proxy_conn_free(pconn);
 
   mark_point();
   url = "ftp+srv://127.0.0.1";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   res = proxy_conn_get_dns_ttl(pconn);
-  fail_unless(res < 0, "Failed to handle SRV URL");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle SRV URL");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
   proxy_conn_free(pconn);
 
   url = "ftps+txt://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   res = proxy_conn_get_dns_ttl(pconn);
-  fail_unless(res < 0, "Failed to handle TXT URL");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle TXT URL");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
   proxy_conn_free(pconn);
 }
@@ -593,11 +593,11 @@ START_TEST (conn_clear_username_test) {
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   username = proxy_conn_get_username(pconn);
-  fail_unless(username == NULL, "Got username unexpectedly");
+  ck_assert_msg(username == NULL, "Got username unexpectedly");
 
   mark_point();
   proxy_conn_clear_username(pconn);
@@ -605,20 +605,20 @@ START_TEST (conn_clear_username_test) {
 
   url = "ftp://user:passwd@127.0.0.1:2121";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   username = proxy_conn_get_username(pconn);
-  fail_unless(username != NULL, "Expected username from conn");
+  ck_assert_msg(username != NULL, "Expected username from conn");
   expected = "user";
-  fail_unless(strcmp(username, expected) == 0,
+  ck_assert_msg(strcmp(username, expected) == 0,
     "Expected username '%s', got '%s'", expected, username);
 
   mark_point();
   proxy_conn_clear_username(pconn);
 
   username = proxy_conn_get_username(pconn);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
 
   proxy_conn_free(pconn);
 }
@@ -633,11 +633,11 @@ START_TEST (conn_clear_password_test) {
 
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd == NULL, "Got password unexpectedly");
+  ck_assert_msg(passwd == NULL, "Got password unexpectedly");
 
   mark_point();
   proxy_conn_clear_password(pconn);
@@ -645,20 +645,20 @@ START_TEST (conn_clear_password_test) {
 
   url = "ftp://user:passwd@127.0.0.1:2121";
   pconn = proxy_conn_create(p, url, 0);
-  fail_if(pconn == NULL, "Failed to create pconn for URL '%s' as expected",
-    url);
+  ck_assert_msg(pconn != NULL,
+    "Failed to create pconn for URL '%s' as expected", url);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd != NULL, "Expected password from conn");
+  ck_assert_msg(passwd != NULL, "Expected password from conn");
   expected = "passwd";
-  fail_unless(strcmp(passwd, expected) == 0,
+  ck_assert_msg(strcmp(passwd, expected) == 0,
     "Expected password '%s', got '%s'", expected, passwd);
 
   mark_point();
   proxy_conn_clear_password(pconn);
 
   passwd = proxy_conn_get_password(pconn);
-  fail_unless(passwd == NULL, "Expected null password, got '%s'", passwd);
+  ck_assert_msg(passwd == NULL, "Expected null password, got '%s'", passwd);
 
   proxy_conn_free(pconn);
 }
@@ -672,23 +672,23 @@ START_TEST (conn_timeout_cb_test) {
   session.notes = pr_table_alloc(p, 0);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
   pr_table_add(session.notes, "mod_proxy.proxy-session", proxy_sess,
     sizeof(struct proxy_session));
 
   addr = pr_netaddr_get_addr(p, "1.2.3.4", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '1.2.3.4': %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to resolve '1.2.3.4': %s", strerror(errno));
   pr_table_add(session.notes, "mod_proxy.proxy-connect-address", addr,
     sizeof(pr_netaddr_t));
 
   proxy_sess->connect_timeout = 1;
   res = proxy_conn_connect_timeout_cb(0, 0, 0, NULL);
-  fail_unless(res == 0, "Failed to handle timeout: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle timeout: %s", strerror(errno));
 
   proxy_sess->connect_timeout = 2;
   res = proxy_conn_connect_timeout_cb(0, 0, 0, NULL);
-  fail_unless(res == 0, "Failed to handle timeout: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle timeout: %s", strerror(errno));
 
   session.notes = NULL;
   proxy_session_free(p, proxy_sess);
@@ -700,13 +700,13 @@ START_TEST (conn_send_proxy_v1_test) {
   conn_t *conn;
 
   res = proxy_conn_send_proxy_v1(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_conn_send_proxy_v1(p, NULL);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
@@ -717,8 +717,8 @@ START_TEST (conn_send_proxy_v1_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v1(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
@@ -726,8 +726,8 @@ START_TEST (conn_send_proxy_v1_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v1(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->local_addr = pr_netaddr_get_addr(p, "::1", FALSE);
@@ -735,8 +735,8 @@ START_TEST (conn_send_proxy_v1_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v1(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->remote_addr = pr_netaddr_get_addr(p, "::1", FALSE);
@@ -744,16 +744,16 @@ START_TEST (conn_send_proxy_v1_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v1(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", FALSE);
 
   mark_point();
   res = proxy_conn_send_proxy_v1(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_inet_close(p, conn);
@@ -767,13 +767,13 @@ START_TEST (conn_send_proxy_v2_test) {
   conn_t *conn;
 
   res = proxy_conn_send_proxy_v2(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_conn_send_proxy_v2(p, NULL);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
@@ -784,8 +784,8 @@ START_TEST (conn_send_proxy_v2_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v2(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
@@ -793,8 +793,8 @@ START_TEST (conn_send_proxy_v2_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v2(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->local_addr = pr_netaddr_get_addr(p, "::1", FALSE);
@@ -802,8 +802,8 @@ START_TEST (conn_send_proxy_v2_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v2(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c->remote_addr = pr_netaddr_get_addr(p, "::1", FALSE);
@@ -811,16 +811,16 @@ START_TEST (conn_send_proxy_v2_test) {
 
   mark_point();
   res = proxy_conn_send_proxy_v2(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn->remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", FALSE);
 
   mark_point();
   res = proxy_conn_send_proxy_v2(p, conn);
-  fail_unless(res < 0, "Failed to handle invalid conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_inet_close(p, conn);

--- a/t/api/db.c
+++ b/t/api/db.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,13 +68,13 @@ START_TEST (db_close_test) {
   int res;
 
   res = proxy_db_close(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   res = proxy_db_close(p, NULL);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 }
 END_TEST
@@ -85,13 +85,13 @@ START_TEST (db_open_test) {
   struct proxy_dbh *dbh;
 
   dbh = proxy_db_open(NULL, NULL, NULL);
-  fail_unless(dbh == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(dbh == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   dbh = proxy_db_open(p, NULL, NULL);
-  fail_unless(dbh == NULL, "Failed to handle null table path");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(dbh == NULL, "Failed to handle null table path");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -99,16 +99,16 @@ START_TEST (db_open_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, NULL);
-  fail_unless(dbh == NULL, "Failed to handle null schema name");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(dbh == NULL, "Failed to handle null schema name");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close table '%s': %s", table_path,
+  ck_assert_msg(res == 0, "Failed to close table '%s': %s", table_path,
     strerror(errno));
 
   (void) unlink(db_test_table);
@@ -122,8 +122,8 @@ START_TEST (db_open_with_version_test) {
   unsigned int schema_version;
 
   dbh = proxy_db_open_with_version(NULL, NULL, NULL, 0, 0);
-  fail_unless(dbh == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
+  ck_assert_msg(dbh == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL, got %s (%d)",
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -134,24 +134,24 @@ START_TEST (db_open_with_version_test) {
   mark_point();
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh != NULL,
+  ck_assert_msg(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   flags |= PROXY_DB_OPEN_FL_INTEGRITY_CHECK;
 
   mark_point();
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh != NULL,
+  ck_assert_msg(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   if (getenv("CI") == NULL &&
       getenv("TRAVIS") == NULL) {
@@ -161,12 +161,12 @@ START_TEST (db_open_with_version_test) {
     mark_point();
     dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
       flags);
-    fail_unless(dbh != NULL,
+    ck_assert_msg(dbh != NULL,
       "Failed to open table '%s', schema '%s', version %u: %s", table_path,
       schema_name, schema_version, strerror(errno));
 
     res = proxy_db_close(p, dbh);
-    fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+    ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
     flags &= ~PROXY_DB_OPEN_FL_VACUUM;
   }
@@ -178,42 +178,42 @@ START_TEST (db_open_with_version_test) {
   flags |= PROXY_DB_OPEN_FL_SCHEMA_VERSION_CHECK|PROXY_DB_OPEN_FL_ERROR_ON_SCHEMA_VERSION_SKEW;
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh == NULL, "Opened table with version skew unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(dbh == NULL, "Opened table with version skew unexpectedly");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   flags &= ~PROXY_DB_OPEN_FL_ERROR_ON_SCHEMA_VERSION_SKEW;
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh != NULL,
+  ck_assert_msg(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   mark_point();
   schema_version = 76;
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh != NULL,
+  ck_assert_msg(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close databas: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close databas: %s", strerror(errno));
 
   mark_point();
   schema_version = 99;
   dbh = proxy_db_open_with_version(p, table_path, schema_name, schema_version,
     flags);
-  fail_unless(dbh != NULL,
+  ck_assert_msg(dbh != NULL,
     "Failed to open table '%s', schema '%s', version %u: %s", table_path,
     schema_name, schema_version, strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -225,13 +225,13 @@ START_TEST (db_exec_stmt_test) {
   struct proxy_dbh *dbh;
 
   res = proxy_db_exec_stmt(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_exec_stmt(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -239,23 +239,23 @@ START_TEST (db_exec_stmt_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_exec_stmt(p, dbh, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null statement");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo;";
   errstr = NULL;
   res = proxy_db_exec_stmt(p, dbh, stmt, &errstr);
-  fail_unless(res < 0, "Failed to execute statement '%s'", stmt);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to execute statement '%s'", stmt);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -278,13 +278,13 @@ START_TEST (db_prepare_stmt_test) {
   struct proxy_dbh *dbh;
 
   res = proxy_db_prepare_stmt(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_prepare_stmt(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -292,42 +292,42 @@ START_TEST (db_prepare_stmt_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null statement");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "foo bar baz?";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res < 0, "Prepared invalid statement '%s' unexpectedly", stmt);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Prepared invalid statement '%s' unexpectedly", stmt);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = create_table(p, dbh, "foo");
-  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   res = create_table(p, dbh, "bar");
-  fail_unless(res == 0, "Failed to create table 'bar': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to create table 'bar': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM bar;";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -339,13 +339,13 @@ START_TEST (db_finish_stmt_test) {
   struct proxy_dbh *dbh;
 
   res = proxy_db_finish_stmt(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_finish_stmt(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -353,38 +353,38 @@ START_TEST (db_finish_stmt_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_finish_stmt(p, dbh, NULL);
-  fail_unless(res < 0, "Failed to handle null statement");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null statement");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo";
   res = proxy_db_finish_stmt(p, dbh, stmt);
-  fail_unless(res < 0, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unprepared statement");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   res = create_table(p, dbh, "foo");
-  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   res = proxy_db_finish_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to finish statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to finish statement '%s': %s", stmt,
     strerror(errno));
 
   res = proxy_db_finish_stmt(p, dbh, stmt);
-  fail_unless(res < 0, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unprepared statement");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -400,13 +400,13 @@ START_TEST (db_bind_stmt_test) {
   void *blob_val;
 
   res = proxy_db_bind_stmt(NULL, NULL, NULL, -1, -1, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_bind_stmt(p, NULL, NULL, -1, -1, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -414,101 +414,101 @@ START_TEST (db_bind_stmt_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_bind_stmt(p, dbh, NULL, -1, -1, NULL, -1);
-  fail_unless(res < 0, "Failed to handle null statement");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null statement");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM table";
   idx = -1;
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL, -1);
-  fail_unless(res < 0, "Failed to handle invalid index %d", idx);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index %d", idx);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   idx = 1;
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL, -1);
-  fail_unless(res < 0, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unprepared statement");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   res = create_table(p, dbh, "foo");
-  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   stmt = "SELECT COUNT(*) FROM foo;";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, NULL, -1);
-  fail_unless(res < 0, "Failed to handle missing INT value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle missing INT value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   int_val = 7;
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val,
     -1);
-  fail_unless(res < 0, "Failed to handle invalid index value");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid index value");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_LONG, NULL,
     -1);
-  fail_unless(res < 0, "Failed to handle missing LONG value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle missing LONG value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   long_val = 7;
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_LONG,
     &long_val, -1);
-  fail_unless(res < 0, "Failed to handle invalid index value");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid index value");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_TEXT, NULL, 0);
-  fail_unless(res < 0, "Failed to handle missing TEXT value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle missing TEXT value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   text_val = "testing";
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_TEXT,
     text_val, 0);
-  fail_unless(res < 0, "Failed to handle invalid index value");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid index value");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_BLOB, NULL,
     -1);
-  fail_unless(res < 0, "Failed to handle missing BLOB value");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle missing BLOB value");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   blob_val = "testing";
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_BLOB,
     blob_val, strlen(blob_val));
-  fail_unless(res < 0, "Failed to handle invalid index value");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid index value");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle invalid NULL value");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid NULL value");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo WHERE id = ?;";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   int_val = 7;
   res = proxy_db_bind_stmt(p, dbh, stmt, idx, PROXY_DB_BIND_TYPE_INT, &int_val,     -1);
-  fail_unless(res == 0, "Failed to bind INT value: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to bind INT value: %s", strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -521,13 +521,13 @@ START_TEST (db_exec_prepared_stmt_test) {
   struct proxy_dbh *dbh;
 
   results = proxy_db_exec_prepared_stmt(NULL, NULL, NULL, NULL);
-  fail_unless(results == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(results == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   results = proxy_db_exec_prepared_stmt(p, NULL, NULL, NULL);
-  fail_unless(results == NULL, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(results == NULL, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -535,34 +535,34 @@ START_TEST (db_exec_prepared_stmt_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   results = proxy_db_exec_prepared_stmt(p, dbh, NULL, NULL);
-  fail_unless(results == NULL, "Failed to handle null statement");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(results == NULL, "Failed to handle null statement");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   stmt = "SELECT COUNT(*) FROM foo;";
   results = proxy_db_exec_prepared_stmt(p, dbh, stmt, &errstr);
-  fail_unless(results == NULL, "Failed to handle unprepared statement");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(results == NULL, "Failed to handle unprepared statement");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   res = create_table(p, dbh, "foo");
-  fail_unless(res == 0, "Failed to create table 'foo': %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to create table 'foo': %s", strerror(errno));
 
   res = proxy_db_prepare_stmt(p, dbh, stmt);
-  fail_unless(res == 0, "Failed to prepare statement '%s': %s", stmt,
+  ck_assert_msg(res == 0, "Failed to prepare statement '%s': %s", stmt,
     strerror(errno));
 
   results = proxy_db_exec_prepared_stmt(p, dbh, stmt, &errstr);
-  fail_unless(results != NULL,
+  ck_assert_msg(results != NULL,
     "Failed to execute prepared statement '%s': %s (%s)", stmt, errstr,
     strerror(errno));
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }
@@ -574,13 +574,13 @@ START_TEST (db_reindex_test) {
   struct proxy_dbh *dbh;
 
   res = proxy_db_reindex(NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_db_reindex(p, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null dbh");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null dbh");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   (void) unlink(db_test_table);
@@ -588,23 +588,23 @@ START_TEST (db_reindex_test) {
   schema_name = "proxy_test";
 
   dbh = proxy_db_open(p, table_path, schema_name);
-  fail_unless(dbh != NULL, "Failed to open table '%s': %s", table_path,
+  ck_assert_msg(dbh != NULL, "Failed to open table '%s': %s", table_path,
     strerror(errno));
 
   res = proxy_db_reindex(p, dbh, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null index name");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null index name");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   index_name = "test_idx";
   res = proxy_db_reindex(p, dbh, index_name, &errstr);
-  fail_unless(res < 0, "Failed to handle invalid index");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle invalid index");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
-  fail_unless(errstr != NULL, "Failed to provide error string");
+  ck_assert_msg(errstr != NULL, "Failed to provide error string");
 
   res = proxy_db_close(p, dbh);
-  fail_unless(res == 0, "Failed to close database: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to close database: %s", strerror(errno));
 
   (void) unlink(db_test_table);
 }

--- a/t/api/dns.c
+++ b/t/api/dns.c
@@ -57,27 +57,27 @@ START_TEST (dns_resolve_einval_test) {
 
   mark_point();
   res = proxy_dns_resolve(NULL, NULL, dns_type, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_dns_resolve(p, NULL, dns_type, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null name argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null name argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   name = "www.google.com";
   res = proxy_dns_resolve(p, name, dns_type, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null resp argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null resp argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle UNKNOWN type argument");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle UNKNOWN type argument");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 }
 END_TEST
@@ -94,27 +94,27 @@ START_TEST (dns_resolve_bad_response_test) {
   mark_point();
   name = "foobarbaz";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no SRV records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no SRV records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = "  ";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no SRV records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no SRV records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = ".";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no SRV records for '%s'", name);
-  fail_unless(errno == ENOENT || errno == EPERM,
+  ck_assert_msg(res < 0, "Failed to handle no SRV records for '%s'", name);
+  ck_assert_msg(errno == ENOENT || errno == EPERM,
     "Expected EPERM (%d) or ENOENT (%d), got %s (%d)", EPERM, ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   /* TXT */
   dns_type = PROXY_DNS_TXT;
@@ -122,34 +122,34 @@ START_TEST (dns_resolve_bad_response_test) {
   mark_point();
   name = "foobarbaz";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no TXT records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no TXT records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = "  ";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no TXT records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no TXT records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = ".";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no TXT records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no TXT records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = "+";
   res = proxy_dns_resolve(p, name, dns_type, &resp, NULL);
-  fail_unless(res < 0, "Failed to handle no TXT records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no TXT records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 }
 END_TEST
 
@@ -163,25 +163,25 @@ START_TEST (dns_resolve_type_srv_test) {
   mark_point();
   name = "_ftps._tcp.castaglia.org";
   res = proxy_dns_resolve(p, name, dns_type, &resp, &ttl);
-  fail_unless(res < 0, "Failed to handle no SRV records for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle no SRV records for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = "_imap._tcp.gmail.com";
   res = proxy_dns_resolve(p, name, dns_type, &resp, &ttl);
-  fail_unless(res < 0, "Failed to handle explicit 'no service' for '%s'", name);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle explicit 'no service' for '%s'", name);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got %s (%d)", ENOENT,
     strerror(errno), errno);
-  fail_unless(resp == NULL, "Expected null responses");
+  ck_assert_msg(resp == NULL, "Expected null responses");
 
   mark_point();
   name = "_imaps._tcp.gmail.com";
   res = proxy_dns_resolve(p, name, dns_type, &resp, &ttl);
-  fail_unless(res > 0, "Failed to resolve SRV records for '%s': %s", name,
+  ck_assert_msg(res > 0, "Failed to resolve SRV records for '%s': %s", name,
     strerror(errno));
-  fail_unless(resp != NULL, "Expected non-null responses");
+  ck_assert_msg(resp != NULL, "Expected non-null responses");
 
   mark_point();
   name = "_ldap._tcp.ru.ac.za";
@@ -190,9 +190,9 @@ START_TEST (dns_resolve_type_srv_test) {
   /* This particular DNS record may not always be there... */
   if (res < 0 &&
       errno != ENOENT) {
-    fail_unless(res > 0, "Failed to resolve SRV records for '%s': %s", name,
+    ck_assert_msg(res > 0, "Failed to resolve SRV records for '%s': %s", name,
       strerror(errno));
-    fail_unless(resp != NULL, "Expected non-null responses");
+    ck_assert_msg(resp != NULL, "Expected non-null responses");
   }
 }
 END_TEST
@@ -211,9 +211,9 @@ START_TEST (dns_resolve_type_txt_test) {
   res = proxy_dns_resolve(p, name, dns_type, &resp, &ttl);
 
   if (getenv("CI") == NULL) {
-    fail_unless(res > 0, "Failed to resolve TXT records for '%s': %s", name,
+    ck_assert_msg(res > 0, "Failed to resolve TXT records for '%s': %s", name,
       strerror(errno));
-    fail_unless(resp != NULL, "Expected non-null responses");
+    ck_assert_msg(resp != NULL, "Expected non-null responses");
   }
 
   mark_point();
@@ -221,9 +221,9 @@ START_TEST (dns_resolve_type_txt_test) {
   res = proxy_dns_resolve(p, name, dns_type, &resp, &ttl);
 
   if (getenv("CI") == NULL) {
-    fail_unless(res > 0, "Failed to resolve TXT records for '%s': %s", name,
+    ck_assert_msg(res > 0, "Failed to resolve TXT records for '%s': %s", name,
       strerror(errno));
-    fail_unless(resp != NULL, "Expected non-null responses");
+    ck_assert_msg(resp != NULL, "Expected non-null responses");
   }
 }
 END_TEST

--- a/t/api/forward.c
+++ b/t/api/forward.c
@@ -46,11 +46,11 @@ static int create_test_dir(void) {
 
   perms = 0770;
   res = mkdir(test_dir, perms);
-  fail_unless(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on directory '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on directory '%s': %s",
     perms, test_dir, strerror(errno));
 
   return 0;
@@ -123,7 +123,7 @@ START_TEST (forward_free_test) {
   int res;
 
   res = proxy_forward_free(NULL);
-  fail_unless(res == 0, "Failed to free Forward API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -132,7 +132,7 @@ START_TEST (forward_init_test) {
   int res;
 
   res = proxy_forward_init(NULL, NULL);
-  fail_unless(res == 0, "Failed to init Forward API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -141,7 +141,7 @@ START_TEST (forward_sess_free_test) {
   int res;
 
   res = proxy_forward_sess_free(NULL, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -150,34 +150,34 @@ START_TEST (forward_sess_init_test) {
   int res;
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL,
+  ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
     "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_forward_sess_init(p, test_dir, NULL);
-  fail_unless(res < 0,
+  ck_assert_msg(res < 0,
     "Initialized Forward API session resources unexpectedly");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   /* Make the connections look like they're from an RFC1918 address. */
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
     "192.168.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_forward_sess_init(p, test_dir, NULL);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -187,29 +187,29 @@ START_TEST (forward_get_method_test) {
   const char *method;
 
   res = proxy_forward_get_method(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   method = "foo";
   res = proxy_forward_get_method(method);
-  fail_unless(res < 0, "Failed to handle unsupported method '%s'", method);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unsupported method '%s'", method);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   method = "proxyuser,user@host";
   res = proxy_forward_get_method(method);
-  fail_unless(res == PROXY_FORWARD_METHOD_USER_WITH_PROXY_AUTH,
+  ck_assert_msg(res == PROXY_FORWARD_METHOD_USER_WITH_PROXY_AUTH,
     "Failed to handle method '%s'", method);
 
   method = "user@host";
   res = proxy_forward_get_method(method);
-  fail_unless(res == PROXY_FORWARD_METHOD_USER_NO_PROXY_AUTH,
+  ck_assert_msg(res == PROXY_FORWARD_METHOD_USER_NO_PROXY_AUTH,
     "Failed to handle method '%s'", method);
 
   method = "proxyuser@host,user";
   res = proxy_forward_get_method(method);
-  fail_unless(res == PROXY_FORWARD_METHOD_PROXY_USER_WITH_PROXY_AUTH,
+  ck_assert_msg(res == PROXY_FORWARD_METHOD_PROXY_USER_WITH_PROXY_AUTH,
     "Failed to handle method '%s'", method);
 }
 END_TEST
@@ -218,7 +218,7 @@ START_TEST (forward_use_proxy_auth_test) {
   int res;
 
   res = proxy_forward_use_proxy_auth();
-  fail_unless(res == TRUE, "Expected true, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected true, got %d", res);
 }
 END_TEST
 
@@ -227,7 +227,7 @@ START_TEST (forward_have_authenticated_test) {
   cmd_rec *cmd = NULL;
 
   res = proxy_forward_have_authenticated(cmd);
-  fail_unless(res == FALSE, "Expected false, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected false, got %d", res);
 }
 END_TEST
 
@@ -271,7 +271,7 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   struct proxy_session *proxy_sess;
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_USER_NO_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -283,8 +283,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled USER command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled USER command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Invalid host (no port) in USER command. */
@@ -294,8 +294,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled USER command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled USER command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Valid host (no port) in USER command. */
@@ -305,8 +305,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 2, "USER", "test@192.168.0.1");
@@ -315,8 +315,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Destination host (WITH bad port syntax) in USER command. */
@@ -326,8 +326,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled USER command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled USER command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Destination host (WITH invalid port) in USER command. */
@@ -337,8 +337,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled USER command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled USER command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Destination host (WITH port) in USER command. */
@@ -348,8 +348,8 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Valid external host (with port) in USER command. */
@@ -359,12 +359,12 @@ START_TEST (forward_handle_user_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -377,7 +377,7 @@ START_TEST (forward_handle_user_userwithproxyauth_test) {
   struct proxy_session *proxy_sess;
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_USER_WITH_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -388,8 +388,8 @@ START_TEST (forward_handle_user_userwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 0, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(block_responses == FALSE, "Expected false, got %d",
+  ck_assert_msg(res == 0, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(block_responses == FALSE, "Expected false, got %d",
     block_responses);
 
   proxy_sess_state |= PROXY_SESS_STATE_PROXY_AUTHENTICATED;
@@ -397,14 +397,14 @@ START_TEST (forward_handle_user_userwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess_state &= ~PROXY_SESS_STATE_PROXY_AUTHENTICATED;
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -417,7 +417,7 @@ START_TEST (forward_handle_user_proxyuserwithproxyauth_test) {
   struct proxy_session *proxy_sess;
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_PROXY_USER_WITH_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -428,8 +428,8 @@ START_TEST (forward_handle_user_proxyuserwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 0, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(block_responses == FALSE, "Expected false, got %d",
+  ck_assert_msg(res == 0, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(block_responses == FALSE, "Expected false, got %d",
     block_responses);
 
   proxy_sess_state |= PROXY_SESS_STATE_PROXY_AUTHENTICATED;
@@ -437,14 +437,14 @@ START_TEST (forward_handle_user_proxyuserwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess_state &= ~PROXY_SESS_STATE_PROXY_AUTHENTICATED;
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -466,7 +466,7 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
   }
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_USER_NO_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -478,8 +478,8 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_pass(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled PASS command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled PASS command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
 /* XXX TODO: Use a file fd for the "backend control conn" fd (/dev/null?) */
@@ -491,8 +491,8 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res == 1, "Failed to handle USER command: %s", strerror(errno));
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == 1, "Failed to handle USER command: %s", strerror(errno));
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   if (getenv("CI") == NULL &&
@@ -503,8 +503,8 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
     mark_point();
     res = proxy_forward_handle_pass(cmd, proxy_sess, &successful,
       &block_responses);
-    fail_unless(res == 1, "Failed to handle PASS command: %s", strerror(errno));
-    fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+    ck_assert_msg(res == 1, "Failed to handle PASS command: %s", strerror(errno));
+    ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
       strerror(errno), errno);
   }
 
@@ -516,7 +516,7 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
     sizeof(struct proxy_session));
 
   res = proxy_tls_init(p, test_dir, PROXY_DB_OPEN_FL_SKIP_VACUUM);
-  fail_unless(res == 0, "Failed to init TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API resources: %s",
     strerror(errno));
 
   c = add_config_param("ProxyTLSEngine", 1, NULL);
@@ -536,7 +536,7 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
  */
 
   res = proxy_tls_sess_init(p, proxy_sess, PROXY_DB_OPEN_FL_SKIP_VACUUM);
-  fail_unless(res == 0, "Failed to init TLS API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API session resources: %s",
     strerror(errno));
 
   /* Valid external host (with port) in USER command. */
@@ -552,19 +552,19 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
     /* Once you've performed a TLS handshake with ftp.cisco.com, it does not
      * accept anonymous logins.  Fine.
      */
-    fail_if(res == 1, "Handled USER command unexpectedly");
-    fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+    ck_assert_msg(res != 1, "Handled USER command unexpectedly");
+    ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
       strerror(errno), errno);
   }
 
   mark_point();
   res = proxy_tls_sess_free(p);
-  fail_unless(res == 0, "Failed to free TLS API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free TLS API session resources: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_tls_free(p);
-  fail_unless(res == 0, "Failed to free TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free TLS API resources: %s",
     strerror(errno));
 
   mark_point();
@@ -573,7 +573,7 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
 
   mark_point();
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -586,7 +586,7 @@ START_TEST (forward_handle_pass_userwithproxyauth_test) {
   struct proxy_session *proxy_sess;
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_USER_WITH_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -598,14 +598,14 @@ START_TEST (forward_handle_pass_userwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_pass(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled PASS command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled PASS command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
 /* XXX TODO: Use a file fd for the "backend control conn" fd (/dev/null?) */
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -618,7 +618,7 @@ START_TEST (forward_handle_pass_proxyuserwithproxyauth_test) {
   struct proxy_session *proxy_sess;
 
   res = forward_sess_init(PROXY_FORWARD_METHOD_PROXY_USER_WITH_PROXY_AUTH);
-  fail_unless(res == 0, "Failed to init Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Forward API session resources: %s",
     strerror(errno));
 
   proxy_sess = forward_get_proxy_sess();
@@ -630,14 +630,14 @@ START_TEST (forward_handle_pass_proxyuserwithproxyauth_test) {
   mark_point();
   res = proxy_forward_handle_pass(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled PASS command unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled PASS command unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
 /* XXX TODO: Use a file fd for the "backend control conn" fd (/dev/null?) */
 
   res = proxy_forward_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Forward API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Forward API session resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);

--- a/t/api/ftp/conn.c
+++ b/t/api/ftp/conn.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -103,55 +103,55 @@ START_TEST (accept_test) {
   conn_t *res, *ctrl_conn = NULL, *data_conn = NULL;
 
   res = proxy_ftp_conn_accept(NULL, NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_conn_accept(p, NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null data conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null data conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   data_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(data_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(data_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_conn_accept(p, data_conn, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   ctrl_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(ctrl_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(ctrl_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   session.xfer.direction = PR_NETIO_IO_RD;
 
   mark_point();
   res = proxy_ftp_conn_accept(p, data_conn, ctrl_conn, FALSE);
-  fail_unless(res == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_conn_accept(p, data_conn, ctrl_conn, TRUE);
-  fail_unless(res == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   session.xfer.direction = PR_NETIO_IO_WR;
 
   mark_point();
   res = proxy_ftp_conn_accept(p, data_conn, ctrl_conn, FALSE);
-  fail_unless(res == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_conn_accept(p, data_conn, ctrl_conn, TRUE);
-  fail_unless(res == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   pr_inet_close(p, ctrl_conn);
@@ -164,17 +164,17 @@ START_TEST (connect_test) {
   const pr_netaddr_t *remote_addr = NULL;
 
   res = proxy_ftp_conn_connect(NULL, NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_conn_connect(p, NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null remote addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null remote addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   remote_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(remote_addr != NULL, "Failed to address for 127.0.0.1: %s",
+  ck_assert_msg(remote_addr != NULL, "Failed to address for 127.0.0.1: %s",
     strerror(errno));
   pr_netaddr_set_port((pr_netaddr_t *) remote_addr, htons(6555));
 
@@ -182,45 +182,45 @@ START_TEST (connect_test) {
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, FALSE);
-  fail_unless(res == NULL, "Failed to handle bad address family");
-  fail_unless(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad address family");
+  ck_assert_msg(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
     ECONNREFUSED, strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, TRUE);
-  fail_unless(res == NULL, "Failed to handle bad address family");
-  fail_unless(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad address family");
+  ck_assert_msg(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
     ECONNREFUSED, strerror(errno), errno);
 
   session.xfer.direction = PR_NETIO_IO_WR;
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, FALSE);
-  fail_unless(res == NULL, "Failed to handle bad address family");
-  fail_unless(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad address family");
+  ck_assert_msg(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
     ECONNREFUSED, strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, TRUE);
-  fail_unless(res == NULL, "Failed to handle bad address family");
-  fail_unless(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad address family");
+  ck_assert_msg(errno == ECONNREFUSED, "Expected ECONNREFUSED (%d), got %s (%d)",
     ECONNREFUSED, strerror(errno), errno);
 
   /* Try connecting to Google's DNS server. */
 
   remote_addr = pr_netaddr_get_addr(p, "8.8.8.8", NULL);
-  fail_unless(remote_addr != NULL, "Failed to resolve '8.8.8.8': %s",
+  ck_assert_msg(remote_addr != NULL, "Failed to resolve '8.8.8.8': %s",
     strerror(errno));
   pr_netaddr_set_port((pr_netaddr_t *) remote_addr, htons(53));
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, FALSE);
-  fail_unless(res != NULL, "Failed to connect: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to connect: %s", strerror(errno));
   pr_inet_close(p, res);
 
   mark_point();
   res = proxy_ftp_conn_connect(p, NULL, remote_addr, TRUE);
-  fail_unless(res != NULL, "Failed to connect: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to connect: %s", strerror(errno));
   pr_inet_close(p, res);
 }
 END_TEST
@@ -230,28 +230,28 @@ START_TEST (listen_test) {
   const pr_netaddr_t *bind_addr = NULL;
 
   res = proxy_ftp_conn_listen(NULL, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_conn_listen(p, NULL, FALSE);
-  fail_unless(res == NULL, "Failed to handle null bind address");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null bind address");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   bind_addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(bind_addr != NULL, "Failed to address for 127.0.0.1: %s",
+  ck_assert_msg(bind_addr != NULL, "Failed to address for 127.0.0.1: %s",
     strerror(errno));
   pr_netaddr_set_port((pr_netaddr_t *) bind_addr, htons(0));
 
   mark_point();
   res = proxy_ftp_conn_listen(p, bind_addr, FALSE);
-  fail_unless(res != NULL, "Failed to listen: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to listen: %s", strerror(errno));
   pr_inet_close(p, res);
 
   mark_point();
   res = proxy_ftp_conn_listen(p, bind_addr, TRUE);
-  fail_unless(res != NULL, "Failed to listen: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to listen: %s", strerror(errno));
   pr_inet_close(p, res);
 }
 END_TEST

--- a/t/api/ftp/ctrl.c
+++ b/t/api/ftp/ctrl.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -73,34 +73,34 @@ START_TEST (handle_async_test) {
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(NULL, NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(p, NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null backend conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null backend conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   backend_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(backend_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(backend_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(p, backend_conn, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null frontend conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null frontend conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   frontend_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(frontend_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(frontend_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(p, backend_conn, frontend_conn, flags);
-  fail_unless(res < 0, "Failed to handle null backend conn stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null backend conn stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, 8, PR_NETIO_IO_RD);
@@ -108,13 +108,13 @@ START_TEST (handle_async_test) {
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(p, backend_conn, frontend_conn, flags);
-  fail_unless(res == 0, "Failed to handle async IO: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle async IO: %s", strerror(errno));
 
   proxy_sess_state |= PROXY_SESS_STATE_CONNECTED;
 
   mark_point();
   res = proxy_ftp_ctrl_handle_async(p, backend_conn, frontend_conn, flags);
-  fail_unless(res == 0, "Failed to handle async IO: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle async IO: %s", strerror(errno));
 
   proxy_sess_state &= ~PROXY_SESS_STATE_CONNECTED;
 
@@ -134,37 +134,37 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(NULL, NULL, NULL, flags);
-  fail_unless(resp == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, NULL, NULL, flags);
-  fail_unless(resp == NULL, "Failed to handle null ctrl conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle null ctrl conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   ctrl_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(ctrl_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(ctrl_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, NULL, flags);
-  fail_unless(resp == NULL, "Failed to handle null response nlines");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle null response nlines");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle EOF");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle EOF");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to open ctrl stream: %s", strerror(errno));
+  ck_assert_msg(nstrm != NULL, "Failed to open ctrl stream: %s", strerror(errno));
 
   pbuf = pr_netio_buffer_alloc(nstrm);
-  fail_unless(pbuf != NULL, "Failed to allocate stream buffer: %s",
+  ck_assert_msg(pbuf != NULL, "Failed to allocate stream buffer: %s",
     strerror(errno));
   buflen = pbuf->buflen;
 
@@ -175,8 +175,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == E2BIG, "Expected E2BIG (%d), got %s (%d)", E2BIG,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == E2BIG, "Expected E2BIG (%d), got %s (%d)", E2BIG,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "Foo\r\n");
@@ -185,8 +185,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "Foo\r\n");
@@ -196,8 +196,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "Food\r\n");
@@ -207,8 +207,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "1ood\r\n");
@@ -217,8 +217,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "12od\r\n");
@@ -227,8 +227,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "123d\r\n");
@@ -237,8 +237,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "001 Foo\r\n");
@@ -247,8 +247,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "999 Foo\r\n");
@@ -257,8 +257,8 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp == NULL, "Failed to handle invalid response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(resp == NULL, "Failed to handle invalid response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   len = snprintf(pbuf->buf, pbuf->buflen-1, "%s", "200 Foo\r\n");
@@ -267,10 +267,10 @@ START_TEST (recv_resp_test) {
 
   mark_point();
   resp = proxy_ftp_ctrl_recv_resp(p, ctrl_conn, &nlines, flags);
-  fail_unless(resp != NULL, "Failed to receive response: %s", strerror(errno));
-  fail_unless(strcmp(resp->num, R_200) == 0, "Expected '%s', got '%s'", R_200,
+  ck_assert_msg(resp != NULL, "Failed to receive response: %s", strerror(errno));
+  ck_assert_msg(strcmp(resp->num, R_200) == 0, "Expected '%s', got '%s'", R_200,
     resp->num);
-  fail_unless(nlines == 1, "Expected 1, got %u", nlines);
+  ck_assert_msg(nlines == 1, "Expected 1, got %u", nlines);
 
   /* XXX TODO: multiline responses! */
 
@@ -284,38 +284,38 @@ START_TEST (send_cmd_test) {
   cmd_rec *cmd;
 
   res = proxy_ftp_ctrl_send_cmd(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_ctrl_send_cmd(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   ctrl_conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(ctrl_conn != NULL, "Failed to create conn: %s",
+  ck_assert_msg(ctrl_conn != NULL, "Failed to create conn: %s",
     strerror(errno));
 
   res = proxy_ftp_ctrl_send_cmd(p, ctrl_conn, NULL);
-  fail_unless(res < 0, "Failed to handle null command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 2, "FOO", "bar");
 
   mark_point();
   res = proxy_ftp_ctrl_send_cmd(p, ctrl_conn, cmd);
-  fail_unless(res < 0, "Failed to handle command without stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle command without stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "FOO");
 
   mark_point();
   res = proxy_ftp_ctrl_send_cmd(p, ctrl_conn, cmd);
-  fail_unless(res < 0, "Failed to handle command without stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle command without stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_inet_close(p, ctrl_conn);
@@ -327,13 +327,13 @@ START_TEST (send_resp_test) {
   pr_response_t *resp;
 
   res = proxy_ftp_ctrl_send_resp(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_ctrl_send_resp(p, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   resp = pcalloc(p, sizeof(pr_response_t));
@@ -341,10 +341,10 @@ START_TEST (send_resp_test) {
   resp->msg = pstrdup(p, "foo bar?");
 
   res = proxy_ftp_ctrl_send_resp(p, NULL, resp, 0);
-  fail_unless(res == 0, "Failed to handle response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle response: %s", strerror(errno));
 
   res = proxy_ftp_ctrl_send_resp(p, NULL, resp, 3);
-  fail_unless(res == 0, "Failed to handle response: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to handle response: %s", strerror(errno));
 }
 END_TEST
 

--- a/t/api/ftp/data.c
+++ b/t/api/ftp/data.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -65,39 +65,39 @@ START_TEST (recv_test) {
 
   mark_point();
   pbuf = proxy_ftp_data_recv(NULL, NULL, FALSE);
-  fail_unless(pbuf == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(pbuf == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   pbuf = proxy_ftp_data_recv(p, NULL, FALSE);
-  fail_unless(pbuf == NULL, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(pbuf == NULL, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   pbuf = proxy_ftp_data_recv(p, conn, FALSE);
-  fail_unless(pbuf == NULL, "Failed to handle missing instream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(pbuf == NULL, "Failed to handle missing instream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_DATA, -1, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed open data stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed open data stream: %s",
     strerror(errno));
 
   mark_point();
   pbuf = proxy_ftp_data_recv(p, conn, FALSE);
-  fail_unless(pbuf == NULL, "Failed to handle bad instream fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(pbuf == NULL, "Failed to handle bad instream fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   pbuf = proxy_ftp_data_recv(p, conn, TRUE);
-  fail_unless(pbuf == NULL, "Failed to handle bad instream fd");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(pbuf == NULL, "Failed to handle bad instream fd");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
 /* Fill in the instrm fd with an fd to an empty file */
@@ -115,33 +115,33 @@ START_TEST (send_test) {
 
   mark_point();
   res = proxy_ftp_data_send(NULL, NULL, NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_data_send(p, NULL, NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = proxy_ftp_data_send(p, conn, NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn->outstrm = pr_netio_open(p, PR_NETIO_STRM_DATA, -1, PR_NETIO_IO_WR);
-  fail_unless(conn->outstrm != NULL, "Failed open data stream: %s",
+  ck_assert_msg(conn->outstrm != NULL, "Failed open data stream: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_data_send(p, conn, NULL, FALSE);
-  fail_unless(res < 0, "Failed to handle null buffer");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buffer");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pbuf = pcalloc(p, sizeof(pr_buffer_t));
@@ -151,14 +151,14 @@ START_TEST (send_test) {
 
   mark_point();
   res = proxy_ftp_data_send(p, conn, pbuf, FALSE);
-  fail_unless(res < 0, "Sent data unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Sent data unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_data_send(p, conn, pbuf, TRUE);
-  fail_unless(res < 0, "Sent data unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
+  ck_assert_msg(res < 0, "Sent data unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got %s (%d)", EBADF,
     strerror(errno), errno);
 
   pr_inet_close(p, conn);

--- a/t/api/ftp/dirlist.c
+++ b/t/api/ftp/dirlist.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2020 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2020-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,14 +58,14 @@ START_TEST (init_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_init(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_init(p, NULL);
-  fail_unless(res < 0, "Failed to handle null proxy_sess");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy_sess");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -75,8 +75,8 @@ START_TEST (finish_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_finish(NULL);
-  fail_unless(res < 0, "Failed to handle null proxy_sess");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy_sess");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -88,30 +88,30 @@ START_TEST (from_dos_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_dos(NULL, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_dos(p, NULL, 0, 0);
-  fail_unless(res == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar baz";
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_dos(p, text, 0, 0);
-  fail_unless(res == NULL, "Failed to handle zero text len");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle zero text len");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   textlen = strlen(text);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_dos(p, text, textlen, 0);
-  fail_unless(res == NULL, "Failed to handle bad text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle bad text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -125,30 +125,30 @@ START_TEST (from_unix_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_unix(NULL, NULL, 0, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_unix(p, NULL, 0, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar baz";
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_unix(p, text, 0, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle zero text len");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle zero text len");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   textlen = strlen(text);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_unix(p, text, textlen, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null tm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null tm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   time(&now);
@@ -156,8 +156,8 @@ START_TEST (from_unix_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_unix(p, text, textlen, tm, 0);
-  fail_unless(res == NULL, "Failed to handle bad text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle bad text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -172,30 +172,30 @@ START_TEST (from_text_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(NULL, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(p, NULL, 0, NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   text = "foo bar baz";
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(p, text, 0, NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle zero text len");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle zero text len");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   textlen = strlen(text);
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(p, text, textlen, NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null tm");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null tm");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   time(&now);
@@ -203,19 +203,19 @@ START_TEST (from_text_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(p, text, textlen, tm, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null userdata");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null userdata");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_dirlist_fileinfo_from_text(p, text, textlen, tm, proxy_sess,
     0);
-  fail_unless(res == NULL, "Failed to handle null proxy_sess->dirlist_ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null proxy_sess->dirlist_ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -229,22 +229,22 @@ START_TEST (to_facts_test) {
 
   mark_point();
   text = proxy_ftp_dirlist_fileinfo_to_facts(NULL, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   text = proxy_ftp_dirlist_fileinfo_to_facts(p, NULL, NULL);
-  fail_unless(text == NULL, "Failed to handle null fileinfo");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null fileinfo");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   pdf = pcalloc(p, sizeof(struct proxy_dirlist_fileinfo));
 
   mark_point();
   text = proxy_ftp_dirlist_fileinfo_to_facts(p, pdf, NULL);
-  fail_unless(text == NULL, "Failed to handle null textlen");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(text == NULL, "Failed to handle null textlen");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -257,63 +257,63 @@ START_TEST (to_text_test) {
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(NULL, NULL, 0, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
   
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, NULL, 0, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null buf");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null buf");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buf = "foo bar baz";
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, 0, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle zero buflen");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero buflen");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   buflen = strlen(buf);
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, buflen, 0, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle zero max textsz");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle zero max textsz");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   maxlen = 1024;
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, buflen, maxlen, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null output text");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null output text");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, buflen, maxlen, &output_text, NULL,
     NULL);
-  fail_unless(res < 0, "Failed to handle null output textlen");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null output textlen");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, buflen, maxlen, &output_text,
     &output_textlen, NULL);
-  fail_unless(res < 0, "Failed to handle null userdata");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null userdata");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, buf, buflen, maxlen, &output_text,
     &output_textlen, proxy_sess);
-  fail_unless(res < 0, "Failed to handle null proxy_sess->dirlist_ctx");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy_sess->dirlist_ctx");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();

--- a/t/api/ftp/msg.c
+++ b/t/api/ftp/msg.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -68,34 +68,34 @@ START_TEST (fmt_addr_test) {
 
   mark_point();
   res = proxy_ftp_msg_fmt_addr(NULL, NULL, 0, FALSE);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_msg_fmt_addr(p, NULL, 0, FALSE);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for 127.0.0.1: %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for 127.0.0.1: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_msg_fmt_addr(p, addr, port, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "127,0,0,1,8,73";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   addr = pr_netaddr_get_addr(p, "169.254.254.254", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for 169.254.254.254: %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for 169.254.254.254: %s",
     strerror(errno));
   res = proxy_ftp_msg_fmt_addr(p, addr, 38550, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "169,254,254,254,150,150";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
 }
@@ -108,57 +108,57 @@ START_TEST (fmt_ext_addr_test) {
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(NULL, NULL, 0, 0, FALSE);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, NULL, 0, 0, FALSE);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for 127.0.0.1: %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for 127.0.0.1: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, addr, port, 0, FALSE);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, addr, port, PR_CMD_EPRT_ID, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "|1|127.0.0.1|2121|";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, addr, port, PR_CMD_EPSV_ID, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "|||2121|";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
 #if PR_USE_IPV6
   addr = pr_netaddr_get_addr(p, "::1", NULL);
-  fail_unless(addr != NULL, "Failed to get addr for ::1: %s",
+  ck_assert_msg(addr != NULL, "Failed to get addr for ::1: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, addr, port, PR_CMD_EPRT_ID, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "|2|::1|2121|";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 
   mark_point();
   res = proxy_ftp_msg_fmt_ext_addr(p, addr, port, PR_CMD_EPSV_ID, FALSE);
-  fail_unless(res != NULL, "Failed to format addr: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to format addr: %s", strerror(errno));
   expected = "|||2121|";
-  fail_unless(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(res, expected) == 0, "Expected '%s', got '%s'",
     expected, res);
 #endif /* PR_USE_IPV6 */
 }
@@ -169,112 +169,112 @@ START_TEST (parse_addr_test) {
   const char *msg, *expected, *ip_str;
 
   res = proxy_ftp_msg_parse_addr(NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_msg_parse_addr(p, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null msg");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null msg");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "foo";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(a,b,c,d,e,f)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(1000,2000,3000,4000,5000,6000)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(1,2,3,4,5000,6000)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(0,0,0,0,1,2)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(1,2,3,4,0,0)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res == NULL, "Failed to handle invalid format");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle invalid format");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(127,0,0,1,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "127.0.0.1";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
-  fail_unless(ntohs(pr_netaddr_get_port(res)) == 2121,
+  ck_assert_msg(ntohs(pr_netaddr_get_port(res)) == 2121,
     "Expected 2121, got %u", ntohs(pr_netaddr_get_port(res)));
 
   msg = "(195,144,107,198,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, 0);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "195.144.107.198";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
-  fail_unless(ntohs(pr_netaddr_get_port(res)) == 2121,
+  ck_assert_msg(ntohs(pr_netaddr_get_port(res)) == 2121,
     "Expected 2121, got %u", ntohs(pr_netaddr_get_port(res)));
 
 #ifdef PR_USE_IPV6
   msg = "(127,0,0,1,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, AF_INET);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "127.0.0.1";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
 
   msg = "(127,0,0,1,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, AF_INET6);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "::ffff:127.0.0.1";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
 
   msg = "(195,144,107,198,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, AF_INET6);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "::ffff:195.144.107.198";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
-  fail_unless(ntohs(pr_netaddr_get_port(res)) == 2121,
+  ck_assert_msg(ntohs(pr_netaddr_get_port(res)) == 2121,
     "Expected 2121, got %u", ntohs(pr_netaddr_get_port(res)));
 
   pr_netaddr_disable_ipv6();
 
   msg = "(127,0,0,1,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, AF_INET6);
-  fail_unless(res != NULL, "Failed to parse message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
     strerror(errno));
   ip_str = pr_netaddr_get_ipstr(res);
   expected = "127.0.0.1";
-  fail_unless(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
+  ck_assert_msg(strcmp(ip_str, expected) == 0, "Expected '%s', got '%s'",
     expected, ip_str);
 
   pr_netaddr_enable_ipv6();
@@ -287,123 +287,123 @@ START_TEST (parse_ext_addr_test) {
   const char *msg; 
 
   res = proxy_ftp_msg_parse_ext_addr(NULL, NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_msg_parse_ext_addr(p, NULL, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null msg");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null msg");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "foo";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, NULL, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to get address for 127.0.0.1: %s",
+  ck_assert_msg(addr != NULL, "Failed to get address for 127.0.0.1: %s",
     strerror(errno));
 
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, 0, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
     EPROTOTYPE, strerror(errno), errno);
 
   /* EPSV response formats */
 
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad EPSV response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle bad EPSV response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(foo";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad EPSV response");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle bad EPSV response");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(foo)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
     EPROTOTYPE, strerror(errno), errno);
 
   msg = "(1)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
     EPROTOTYPE, strerror(errno), errno);
 
   msg = "(|4)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
     EPROTOTYPE, strerror(errno), errno);
 
   msg = "(|0)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPROTOTYPE, "Expected EPROTOTYPE (%d), got '%s' (%d)",
     EPROTOTYPE, strerror(errno), errno);
 
   msg = "(|1)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|2)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle bad network protocol");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle bad network protocol");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   /* Where the network protocol matches that of the address... */
   msg = "(|1|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle badly formatted message");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle badly formatted message");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(|1|1.2.3.4)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle badly formatted message");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle badly formatted message");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   msg = "(|1|1.2.3.4|5)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle badly formatted message");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle badly formatted message");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|1|1.2.3.4|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(||1.2.3.4|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(||1.2.3.4|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, "all");
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(||1.2.3.4|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, "1");
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(|||5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
-  fail_unless(
+  ck_assert_msg(
     strcmp(pr_netaddr_get_ipstr(addr), pr_netaddr_get_ipstr(res)) == 0,
     "Expected '%s', got '%s'", pr_netaddr_get_ipstr(addr),
     pr_netaddr_get_ipstr(res));
@@ -412,72 +412,72 @@ START_TEST (parse_ext_addr_test) {
 
   msg = "(||::1|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|2|1.2.3.4|5)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
 #ifdef PR_USE_IPV6
   addr = pr_netaddr_get_addr(p, "::1", NULL);
-  fail_unless(addr != NULL, "Failed to get address for ::1: %s",
+  ck_assert_msg(addr != NULL, "Failed to get address for ::1: %s",
     strerror(errno));
 
   msg = "(|2|1.2.3.4|5)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|1|::1|5)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|2|::1|5)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   msg = "(|2|::1|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(|2|::1|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, "ALL");
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(||::1|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, "2");
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(||::1|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
 
   msg = "(|||5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res != NULL, "Failed to handle formatted message '%s': %s", msg,
+  ck_assert_msg(res != NULL, "Failed to handle formatted message '%s': %s", msg,
     strerror(errno));
-  fail_unless(
+  ck_assert_msg(
     strcmp(pr_netaddr_get_ipstr(addr), pr_netaddr_get_ipstr(res)) == 0,
     "Expected '%s', got '%s'", pr_netaddr_get_ipstr(addr),
     pr_netaddr_get_ipstr(res));
 
   msg = "(||1.2.3.4|5|)";
   res = proxy_ftp_msg_parse_ext_addr(p, msg, addr, PR_CMD_EPSV_ID, NULL);
-  fail_unless(res == NULL, "Failed to handle network protocol mismatch");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res == NULL, "Failed to handle network protocol mismatch");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 #endif /* PR_USE_IPV6 */
 }

--- a/t/api/ftp/sess.c
+++ b/t/api/ftp/sess.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -60,21 +60,21 @@ START_TEST (get_feat_test) {
   const struct proxy_session *proxy_sess = NULL;
 
   res = proxy_ftp_sess_get_feat(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_sess_get_feat(p, NULL);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
  
   proxy_sess = proxy_session_alloc(p);
 
   mark_point();
   res = proxy_ftp_sess_get_feat(p, proxy_sess);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
  
   proxy_session_free(p, proxy_sess);
@@ -86,13 +86,13 @@ START_TEST (send_auth_tls_test) {
   const struct proxy_session *proxy_sess = NULL;
 
   res = proxy_ftp_sess_send_auth_tls(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_sess_send_auth_tls(p, NULL);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = proxy_session_alloc(p);
@@ -100,8 +100,8 @@ START_TEST (send_auth_tls_test) {
   mark_point();
   res = proxy_ftp_sess_send_auth_tls(p, proxy_sess);
 #ifdef PR_USE_OPENSSL
-  fail_unless(res < 0, "Sent AUTH TLS unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Sent AUTH TLS unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 #endif /* PR_USE_OPENSSL */
 
@@ -114,20 +114,20 @@ START_TEST (send_host_test) {
   const struct proxy_session *proxy_sess = NULL;
 
   res = proxy_ftp_sess_send_host(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_sess_send_host(p, NULL);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = proxy_session_alloc(p);
 
   mark_point();
   res = proxy_ftp_sess_send_host(p, proxy_sess);
-  fail_unless(res == 0, "Failed to (maybe) send HOST: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to (maybe) send HOST: %s", strerror(errno));
 
   proxy_session_free(p, proxy_sess);
 }
@@ -138,20 +138,20 @@ START_TEST (send_pbsz_prot_test) {
   const struct proxy_session *proxy_sess = NULL;
 
   res = proxy_ftp_sess_send_pbsz_prot(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_sess_send_pbsz_prot(p, NULL);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = proxy_session_alloc(p);
 
   mark_point();
   res = proxy_ftp_sess_send_pbsz_prot(p, proxy_sess);
-  fail_unless(res == 0, "Failed to (maybe) send PBSZ/PROT: %s",
+  ck_assert_msg(res == 0, "Failed to (maybe) send PBSZ/PROT: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);

--- a/t/api/ftp/xfer.c
+++ b/t/api/ftp/xfer.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -95,48 +95,48 @@ START_TEST (prepare_active_test) {
   struct proxy_session *proxy_sess = NULL;
 
   res = proxy_ftp_xfer_prepare_active(0, NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "FOO");
 
   res = proxy_ftp_xfer_prepare_active(0, cmd, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null error code");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null error code");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_ftp_xfer_prepare_active(0, cmd, "500", NULL, 0);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
 
   mark_point();
   res = proxy_ftp_xfer_prepare_active(0, cmd, "500", proxy_sess, 0);
-  fail_unless(res < 0, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess->backend_ctrl_conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY,
     FALSE);
-  fail_unless(proxy_sess->backend_ctrl_conn != NULL,
+  ck_assert_msg(proxy_sess->backend_ctrl_conn != NULL,
     "Failed to open backend control conn: %s", strerror(errno));
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL,
+  ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
     "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_ftp_xfer_prepare_active(0, cmd, "500", proxy_sess, 0);
-  fail_unless(res < 0, "Failed to handle illegal FTP command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle illegal FTP command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Prevent NULL pointer dereferences which would only happen during
@@ -147,31 +147,31 @@ START_TEST (prepare_active_test) {
   mark_point();
   res = proxy_ftp_xfer_prepare_active(PR_CMD_PORT_ID, cmd, "500", proxy_sess,
     0);
-  fail_unless(res < 0, "Failed to handle bad PORT command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad PORT command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_ftp_xfer_prepare_active(PR_CMD_EPRT_ID, cmd, "500", proxy_sess,
     0);
-  fail_unless(res < 0, "Failed to handle bad EPRT command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad EPRT command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "EPRT");
 
   mark_point();
   res = proxy_ftp_xfer_prepare_active(0, cmd, "500", proxy_sess, 0);
-  fail_unless(res < 0, "Failed to handle bad EPRT command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad EPRT command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "PORT");
 
   mark_point();
   res = proxy_ftp_xfer_prepare_active(0, cmd, "500", proxy_sess, 0);
-  fail_unless(res < 0, "Failed to handle bad PORT command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle bad PORT command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_inet_close(p, session.c);
@@ -185,48 +185,48 @@ START_TEST (prepare_passive_test) {
   struct proxy_session *proxy_sess;
 
   addr = proxy_ftp_xfer_prepare_passive(0, NULL, NULL, NULL, 0);
-  fail_unless(addr == NULL, "Failed to handle null command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "FOO");
 
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, NULL, NULL, 0);
-  fail_unless(addr == NULL, "Failed to handle null error code");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null error code");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, "500", NULL, 0);
-  fail_unless(addr == NULL, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
 
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, "500", proxy_sess, 0);
-  fail_unless(addr == NULL, "Failed to handle null proxy session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle null proxy session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess->backend_ctrl_conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY,
     FALSE);
-  fail_unless(proxy_sess->backend_ctrl_conn != NULL,
+  ck_assert_msg(proxy_sess->backend_ctrl_conn != NULL,
     "Failed to open backend control conn: %s", strerror(errno));
   
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL,
+  ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
     "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, "500", proxy_sess, 0);
-  fail_unless(addr == NULL, "Failed to handle illegal FTP command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle illegal FTP command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   /* Prevent NULL pointer dereferences which would only happen during
@@ -237,31 +237,31 @@ START_TEST (prepare_passive_test) {
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(PR_CMD_PASV_ID, cmd, "500", proxy_sess,
     0);
-  fail_unless(addr == NULL, "Failed to handle bad PASV command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle bad PASV command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(PR_CMD_EPSV_ID, cmd, "500", proxy_sess,
     0);
-  fail_unless(addr == NULL, "Failed to handle bad EPSV command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle bad EPSV command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "EPSV");
 
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, "500", proxy_sess, 0);
-  fail_unless(addr == NULL, "Failed to handle bad EPSV command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle bad EPSV command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   cmd = pr_cmd_alloc(p, 1, "PASV");
 
   mark_point();
   addr = proxy_ftp_xfer_prepare_passive(0, cmd, "500", proxy_sess, 0);
-  fail_unless(addr == NULL, "Failed to handle bad PASV command");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(addr == NULL, "Failed to handle bad PASV command");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   pr_inet_close(p, session.c);

--- a/t/api/inet.c
+++ b/t/api/inet.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2017 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -75,8 +75,8 @@ START_TEST (inet_accept_test) {
 
   mark_point();
   conn = proxy_inet_accept(NULL, NULL, NULL, -1, -1, FALSE);
-  fail_unless(conn == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(conn == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -88,7 +88,7 @@ START_TEST (inet_close_test) {
   proxy_inet_close(NULL, NULL);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   conn->rfd = conn->wfd = 999;
@@ -103,33 +103,33 @@ START_TEST (inet_connect_ipv4_test) {
 
   mark_point();
   res = proxy_inet_connect(NULL, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_inet_connect(p, NULL, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, NULL, 0);
-  fail_unless(res < 0, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '127.0.0.1': %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 80);
-  fail_unless(res < 0, "Connected to 127.0.0.1#80 unexpectedly");
-  fail_unless(errno == ECONNREFUSED,
+  ck_assert_msg(res < 0, "Connected to 127.0.0.1#80 unexpectedly");
+  ck_assert_msg(errno == ECONNREFUSED,
     "Expected ECONNREFUSED (%d), got '%s' (%d)", ECONNREFUSED,
     strerror(errno), errno);
   proxy_inet_close(p, conn);
@@ -137,15 +137,16 @@ START_TEST (inet_connect_ipv4_test) {
   /* Try connecting to Google's DNS server. */
 
   addr = pr_netaddr_get_addr(p, "8.8.8.8", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '8.8.8.8': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '8.8.8.8': %s",
     strerror(errno));
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 53);
-  fail_if(res < 0, "Failed to connect to 8.8.8.8#53: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to connect to 8.8.8.8#53: %s",
+    strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
@@ -153,33 +154,35 @@ START_TEST (inet_connect_ipv4_test) {
   /* Now start supplying in/out streams. */
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 53);
-  fail_if(res < 0, "Failed to connect to 8.8.8.8#53: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to connect to 8.8.8.8#53: %s",
+    strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
 
   conn->outstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_WR);
-  fail_unless(conn->outstrm != NULL, "Failed to open othr writing stream: %s",
+  ck_assert_msg(conn->outstrm != NULL, "Failed to open othr writing stream: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 53);
-  fail_if(res < 0, "Failed to connect to 8.8.8.8#53: %s", strerror(errno));
+  ck_assert_msg(res >= 0, "Failed to connect to 8.8.8.8#53: %s",
+    strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
@@ -199,15 +202,15 @@ START_TEST (inet_connect_ipv6_test) {
   pr_inet_set_default_family(p, AF_INET6);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   addr = pr_netaddr_get_addr(p, "::1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '::1': %s", strerror(errno));
+  ck_assert_msg(addr != NULL, "Failed to resolve '::1': %s", strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 80);
-  fail_unless(res < 0, "Connected to 127.0.0.1#80 unexpectedly");
-  fail_unless(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+  ck_assert_msg(res < 0, "Connected to 127.0.0.1#80 unexpectedly");
+  ck_assert_msg(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
     "Expected ECONNREFUSED (%d), ENETUNREACH (%d), or EADDRNOTAVAIL (%d), got %s (%d)",
     ECONNREFUSED, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
   proxy_inet_close(p, conn);
@@ -215,17 +218,17 @@ START_TEST (inet_connect_ipv6_test) {
   /* Try connecting to Google's DNS server. */
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   addr = pr_netaddr_get_addr(p, "2001:4860:4860::8888", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '2001:4860:4860::8888': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '2001:4860:4860::8888': %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_connect(p, conn, addr, 53);
   if (res < 0) {
     /* This could be expected, e.g. if there's no route. */
-    fail_unless(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
+    ck_assert_msg(errno == ECONNREFUSED || errno == ENETUNREACH || errno == EADDRNOTAVAIL,
       "Expected ECONNREFUSED (%d), ENETUNREACH (%d), or EADDRNOTAVAIL (%d), got %s (%d)",
       ECONNREFUSED, ENETUNREACH, EADDRNOTAVAIL, strerror(errno), errno);
   }
@@ -248,22 +251,22 @@ START_TEST (inet_listen_test) {
 
   mark_point();
   res = proxy_inet_listen(NULL, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_inet_listen(p, NULL, 0, 0);
-  fail_unless(res < 0, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   mark_point();
   res = proxy_inet_listen(p, conn, 5, 0);
-  fail_unless(res == 0, "Failed to listen on conn: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to listen on conn: %s", strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
@@ -271,33 +274,33 @@ START_TEST (inet_listen_test) {
   /* Now start providing in/out streams. */
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_listen(p, conn, 5, 0);
-  fail_unless(res == 0, "Failed to listen on conn: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to listen on conn: %s", strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
 
   conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   conn->instrm = pr_netio_open(p, PR_NETIO_STRM_CTRL, -1, PR_NETIO_IO_RD);
-  fail_unless(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
+  ck_assert_msg(conn->instrm != NULL, "Failed to open ctrl reading stream: %s",
     strerror(errno));
 
   conn->outstrm = pr_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_WR);
-  fail_unless(conn->outstrm != NULL, "Failed to open othr writing stream: %s",
+  ck_assert_msg(conn->outstrm != NULL, "Failed to open othr writing stream: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_inet_listen(p, conn, 5, 0);
-  fail_unless(res == 0, "Failed to listen on conn: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to listen on conn: %s", strerror(errno));
 
   mark_point();
   proxy_inet_close(p, conn);
@@ -310,33 +313,33 @@ START_TEST (inet_openrw_test) {
 
   res = proxy_inet_openrw(NULL, NULL, NULL, PR_NETIO_STRM_CTRL, -1, -1, -1,
     FALSE);
-  fail_unless(res == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_inet_openrw(p, NULL, NULL, PR_NETIO_STRM_CTRL, -1, -1, -1,
     FALSE);
-  fail_unless(res == NULL, "Failed to handle null conn");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null conn");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   conn = pr_inet_create_conn(p, -2, NULL, INPORT_ANY, FALSE);
-  fail_unless(conn != NULL, "Failed to create conn: %s", strerror(errno));
+  ck_assert_msg(conn != NULL, "Failed to create conn: %s", strerror(errno));
 
   res = proxy_inet_openrw(p, conn, NULL, PR_NETIO_STRM_OTHR, -1, -1, -1,
     FALSE);
-  fail_unless(res == NULL, "Failed to handle null addr");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res == NULL, "Failed to handle null addr");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
   proxy_inet_close(p, conn);
 
   addr = pr_netaddr_get_addr(p, "127.0.0.1", NULL);
-  fail_unless(addr != NULL, "Failed to resolve '127.0.0.1': %s",
+  ck_assert_msg(addr != NULL, "Failed to resolve '127.0.0.1': %s",
     strerror(errno));
 
   res = proxy_inet_openrw(p, conn, addr, PR_NETIO_STRM_OTHR, -1, -1, -1,
     FALSE);
-  fail_unless(res != NULL, "Failed to open rw conn: %s", strerror(errno));
+  ck_assert_msg(res != NULL, "Failed to open rw conn: %s", strerror(errno));
   proxy_inet_close(p, conn);
 }
 END_TEST

--- a/t/api/netio.c
+++ b/t/api/netio.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2020 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,8 +61,8 @@ START_TEST (netio_close_test) {
   int res;
 
   res = proxy_netio_close(NULL);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -72,22 +72,22 @@ START_TEST (netio_open_test) {
   pr_netio_stream_t *nstrm;
 
   nstrm = proxy_netio_open(NULL, 0, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm == NULL, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(nstrm == NULL, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, 77, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm == NULL, "Failed to handle unsupported stream type");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(nstrm == NULL, "Failed to handle unsupported stream type");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -97,22 +97,22 @@ START_TEST (netio_poll_test) {
   pr_netio_stream_t *nstrm;
 
   res = proxy_netio_poll(NULL);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   res = proxy_netio_poll(nstrm);
-  fail_unless(res < 0, "Polled stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Polled stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -122,20 +122,20 @@ START_TEST (netio_postopen_test) {
   pr_netio_stream_t *nstrm;
 
   res = proxy_netio_postopen(NULL);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   res = proxy_netio_postopen(nstrm);
-  fail_unless(res == 0, "Failed to postopen stream: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to postopen stream: %s", strerror(errno));
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -145,22 +145,22 @@ START_TEST (netio_printf_test) {
   pr_netio_stream_t *nstrm;
 
   res = proxy_netio_printf(NULL, "%s", "foo");
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   res = proxy_netio_printf(nstrm, "%d", 7);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -176,23 +176,23 @@ START_TEST (netio_read_test) {
 
   mark_point();
   res = proxy_netio_read(NULL, buf, bufsz, 1);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_netio_read(nstrm, buf, bufsz, 1);
-  fail_unless(res < 0, "Successfully read from stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully read from stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -205,15 +205,15 @@ START_TEST (netio_reset_poll_interval_test) {
   proxy_netio_reset_poll_interval(NULL);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   mark_point();
   proxy_netio_reset_poll_interval(nstrm);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -226,15 +226,15 @@ START_TEST (netio_set_poll_interval_test) {
   proxy_netio_set_poll_interval(NULL, 1);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   mark_point();
   proxy_netio_set_poll_interval(nstrm, 1);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -245,23 +245,23 @@ START_TEST (netio_shutdown_test) {
 
   mark_point();
   res = proxy_netio_shutdown(NULL, 0);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_netio_shutdown(nstrm, 0);
-  fail_unless(res < 0, "Successfully shutdown stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully shutdown stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -272,23 +272,23 @@ START_TEST (netio_write_test) {
 
   mark_point();
   res = proxy_netio_write(NULL, "foo", 3);
-  fail_unless(res < 0, "Failed to handle null stream");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null stream");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   nstrm = proxy_netio_open(p, PR_NETIO_STRM_OTHR, -1, PR_NETIO_IO_RD);
-  fail_unless(nstrm != NULL, "Failed to handle othr stream type: %s",
+  ck_assert_msg(nstrm != NULL, "Failed to handle othr stream type: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_netio_write(nstrm, "foo", 1);
-  fail_unless(res < 0, "Wrote to stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Wrote to stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 
   res = proxy_netio_close(nstrm);
-  fail_unless(res < 0, "Successfully closed stream unexpectedly");
-  fail_unless(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
+  ck_assert_msg(res < 0, "Successfully closed stream unexpectedly");
+  ck_assert_msg(errno == EBADF, "Expected EBADF (%d), got '%s' (%d)", EBADF,
     strerror(errno), errno);
 }
 END_TEST
@@ -298,55 +298,55 @@ START_TEST (netio_set_test) {
   int res, strm_type = PR_NETIO_STRM_OTHR;
 
   netio = proxy_netio_unset(strm_type, NULL);
-  fail_unless(netio == NULL, "Failed to handle null function string");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(netio == NULL, "Failed to handle null function string");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   netio = proxy_netio_unset(strm_type, "foo");
-  fail_unless(netio == NULL, "Expected null othr NetIO, got %p", netio);
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(netio == NULL, "Expected null othr NetIO, got %p", netio);
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set null othr netio: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set null othr netio: %s", strerror(errno));
 
   strm_type = PR_NETIO_STRM_CTRL;
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set null ctrl netio: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set null ctrl netio: %s", strerror(errno));
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set null ctrl netio again: %s",
+  ck_assert_msg(res == 0, "Failed to set null ctrl netio again: %s",
     strerror(errno));
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set ctrl netio: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set ctrl netio: %s", strerror(errno));
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set ctrl netio again: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set ctrl netio again: %s", strerror(errno));
 
   netio = proxy_netio_unset(strm_type, "testcase");
-  fail_unless(netio != NULL, "Failed to unset ctrl netio: %s", strerror(errno));
+  ck_assert_msg(netio != NULL, "Failed to unset ctrl netio: %s", strerror(errno));
 
   strm_type = PR_NETIO_STRM_DATA;
   netio = NULL;
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set null data netio: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set null data netio: %s", strerror(errno));
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set null data netio again: %s",
+  ck_assert_msg(res == 0, "Failed to set null data netio again: %s",
     strerror(errno));
 
   netio = pr_alloc_netio2(p, NULL, "testsuite");
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set data netio: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set data netio: %s", strerror(errno));
 
   res = proxy_netio_set(strm_type, netio);
-  fail_unless(res == 0, "Failed to set data netio again: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to set data netio again: %s", strerror(errno));
 
   netio = proxy_netio_unset(strm_type, "testcase");
-  fail_unless(netio != NULL, "Failed to unset data netio: %s", strerror(errno));
+  ck_assert_msg(netio != NULL, "Failed to unset data netio: %s", strerror(errno));
 }
 END_TEST
 
@@ -355,46 +355,46 @@ START_TEST (netio_use_test) {
   int res, strm_type = PR_NETIO_STRM_OTHR;
 
   res = proxy_netio_using(strm_type, NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_netio_using(strm_type, &netio);
-  fail_unless(res < 0, "Failed to handle othr stream type");
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle othr stream type");
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   res = proxy_netio_using(PR_NETIO_STRM_CTRL, &netio);
-  fail_unless(res == 0, "Failed to handle ctrl stream type: %s",
+  ck_assert_msg(res == 0, "Failed to handle ctrl stream type: %s",
     strerror(errno));
-  fail_unless(netio == NULL, "Expected null ctrl netio, got %p", netio);
+  ck_assert_msg(netio == NULL, "Expected null ctrl netio, got %p", netio);
 
   res = proxy_netio_using(PR_NETIO_STRM_DATA, &netio);
-  fail_unless(res == 0, "Failed to handle data stream type: %s",
+  ck_assert_msg(res == 0, "Failed to handle data stream type: %s",
     strerror(errno));
-  fail_unless(netio == NULL, "Expected null data netio, got %p", netio);
+  ck_assert_msg(netio == NULL, "Expected null data netio, got %p", netio);
 
   res = proxy_netio_use(strm_type, NULL);
-  fail_unless(res < 0, "Failed to handle othr stream type");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
+  ck_assert_msg(res < 0, "Failed to handle othr stream type");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
     strerror(errno), errno);
 
   res = proxy_netio_use(PR_NETIO_STRM_CTRL, NULL);
-  fail_unless(res == 0, "Failed to handle ctrl stream type: %s",
+  ck_assert_msg(res == 0, "Failed to handle ctrl stream type: %s",
     strerror(errno));
 
   netio = proxy_netio_unset(PR_NETIO_STRM_CTRL, "testcase");
-  fail_unless(netio == NULL, "Unset ctrl stream unexpectedly");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
+  ck_assert_msg(netio == NULL, "Unset ctrl stream unexpectedly");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
     strerror(errno), errno);
 
   res = proxy_netio_use(PR_NETIO_STRM_DATA, NULL);
-  fail_unless(res == 0, "Failed to handle data stream type: %s",
+  ck_assert_msg(res == 0, "Failed to handle data stream type: %s",
     strerror(errno));
 
   netio = proxy_netio_unset(PR_NETIO_STRM_DATA, "testcase");
-  fail_unless(netio == NULL, "Unset data stream unexpectedly");
-  fail_unless(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
+  ck_assert_msg(netio == NULL, "Unset data stream unexpectedly");
+  ck_assert_msg(errno == ENOSYS, "Expected ENOSYS (%d), got '%s' (%d)", ENOSYS,
     strerror(errno), errno);
 
 }

--- a/t/api/random.c
+++ b/t/api/random.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2013-2016 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2013-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -58,8 +58,10 @@ START_TEST (random_next_range_10_test) {
     long num;
 
     num = proxy_random_next(min, max);
-    fail_if(num < min, "random number %ld less than minimum %ld", num, min);
-    fail_if(num > max, "random number %ld greater than maximum %ld", num, max);
+    ck_assert_msg(num >= min, "random number %ld less than minimum %ld", num,
+      min);
+    ck_assert_msg(num <= max, "random number %ld greater than maximum %ld", num,
+      max);
   }
 }
 END_TEST
@@ -78,8 +80,10 @@ START_TEST (random_next_range_1000_test) {
     long num;
 
     num = proxy_random_next(min, max);
-    fail_if(num < min, "random number %ld less than minimum %ld", num, min);
-    fail_if(num > max, "random number %ld greater than maximum %ld", num, max);
+    ck_assert_msg(num >= min, "random number %ld less than minimum %ld", num,
+      min);
+    ck_assert_msg(num <= max, "random number %ld greater than maximum %ld", num,
+      max);
 
     seen[num] = 1;
   }
@@ -88,7 +92,7 @@ START_TEST (random_next_range_1000_test) {
    * good, right?
    */
   for (i = 0; i < count; i++) {
-    fail_unless(seen[i] == 1, "Expected to have generated number %d", i);
+    ck_assert_msg(seen[i] == 1, "Expected to have generated number %d", i);
   }
 }
 END_TEST

--- a/t/api/reverse.c
+++ b/t/api/reverse.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2013-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2013-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -56,21 +56,21 @@ static FILE *test_prep(void) {
   res = mkdir(test_dir, perms);
   if (res < 0 &&
       errno != EEXIST) {
-    fail_unless(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
+    ck_assert_msg(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
       strerror(errno));
   }
 
   res = chmod(test_dir, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on directory '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on directory '%s': %s",
     perms, test_dir, strerror(errno));
 
   fh = fopen(test_file, "w+");
-  fail_if(fh == NULL, "Failed to create tmp file '%s': %s", test_file,
+  ck_assert_msg(fh != NULL, "Failed to create tmp file '%s': %s", test_file,
     strerror(errno));
 
   perms = 0660;
   res = chmod(test_file, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on file '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on file '%s': %s",
     perms, test_file, strerror(errno));
 
   return fh;
@@ -144,12 +144,12 @@ START_TEST (reverse_free_test) {
   int res;
 
   res = proxy_reverse_free(NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -159,13 +159,13 @@ START_TEST (reverse_init_test) {
   FILE *fh;
 
   res = proxy_reverse_init(NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_reverse_init(p, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null tables dir");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null tables dir");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   fh = test_prep();
@@ -173,11 +173,11 @@ START_TEST (reverse_init_test) {
 
   mark_point();
   res = proxy_reverse_init(p, test_dir, flags);
-  fail_unless(res == 0, "Failed to init Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Reverse API resources: %s",
     strerror(errno));
 
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -189,7 +189,7 @@ START_TEST (reverse_sess_free_test) {
 
   mark_point();
   res = proxy_reverse_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Reverse API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API session resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -203,14 +203,14 @@ START_TEST (reverse_sess_init_test) {
 
   mark_point();
   res = proxy_reverse_sess_init(NULL, NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_reverse_sess_init(p, NULL, NULL, flags);
-  fail_unless(res < 0, "Unexpectedly init'd Reverse API session resources");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Unexpectedly init'd Reverse API session resources");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   c = add_config_param("ProxyReverseServers", 2, NULL, NULL);
@@ -229,13 +229,13 @@ START_TEST (reverse_sess_init_test) {
 
   mark_point();
   res = proxy_reverse_sess_init(NULL, NULL, NULL, flags);
-  fail_unless(res < 0, "Unexpectedly init'd Reverse API session resources");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Unexpectedly init'd Reverse API session resources");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_reverse_sess_free(p, NULL);
-  fail_unless(res == 0, "Failed to free Reverse API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API session resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -288,16 +288,16 @@ START_TEST (reverse_connect_policy_random_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_RANDOM, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy Random: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy Random: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -308,16 +308,16 @@ START_TEST (reverse_connect_policy_roundrobin_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_ROUND_ROBIN, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy RoundRobin: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy RoundRobin: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -328,16 +328,16 @@ START_TEST (reverse_connect_policy_leastconns_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_LEAST_CONNS, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy LeastConns: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy LeastConns: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -349,17 +349,17 @@ START_TEST (reverse_connect_policy_leastresponsetime_test) {
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_LEAST_RESPONSE_TIME,
     NULL);
-  fail_unless(res == 0,
+  ck_assert_msg(res == 0,
     "Failed to test ReverseConnectPolicy LeastResponseTime: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -370,16 +370,16 @@ START_TEST (reverse_connect_policy_shuffle_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_SHUFFLE, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy Shuffle: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy Shuffle: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -390,16 +390,16 @@ START_TEST (reverse_connect_policy_peruser_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_PER_USER, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy PerUser: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy PerUser: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -413,17 +413,17 @@ START_TEST (reverse_connect_policy_pergroup_test) {
    * enabled.
    */
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_PER_GROUP, NULL);
-  fail_unless(res < 0, "Expected ReverseConnectPolicy PerGroup to fail");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
+  ck_assert_msg(res < 0, "Expected ReverseConnectPolicy PerGroup to fail");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -434,16 +434,16 @@ START_TEST (reverse_connect_policy_perhost_test) {
   int res;
 
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_PER_HOST, NULL);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy PerHost: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy PerHost: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   test_cleanup(p);
@@ -462,7 +462,7 @@ static void test_handle_user_pass(int policy_id, array_header *src_backends) {
 
   mark_point();
   res = test_connect_policy(PROXY_REVERSE_CONNECT_POLICY_RANDOM, src_backends);
-  fail_unless(res == 0, "Failed to test ReverseConnectPolicy Random: %s",
+  ck_assert_msg(res == 0, "Failed to test ReverseConnectPolicy Random: %s",
     strerror(errno));
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
@@ -472,17 +472,17 @@ static void test_handle_user_pass(int policy_id, array_header *src_backends) {
     sizeof(struct proxy_session));
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL,
+  ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));
 
   session.c->local_addr = session.c->remote_addr = pr_netaddr_get_addr(p,
     "127.0.0.1", NULL);
-  fail_unless(session.c->remote_addr != NULL, "Failed to get address: %s",
+  ck_assert_msg(session.c->remote_addr != NULL, "Failed to get address: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_reverse_sess_init(p, test_dir, proxy_sess, flags);
-  fail_unless(res == 0, "Failed to init Reverse API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init Reverse API session resources: %s",
     strerror(errno));
 
   cmd = pr_cmd_alloc(p, 2, "USER", "anonymous");
@@ -491,7 +491,7 @@ static void test_handle_user_pass(int policy_id, array_header *src_backends) {
   mark_point();
   res = proxy_reverse_handle_user(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_if(res != 1, "Failed to handle USER");
+  ck_assert_msg(res == 1, "Failed to handle USER");
 
   cmd = pr_cmd_alloc(p, 2, "PASS", "ftp@nospam.org");
   cmd->arg = pstrdup(p, "ftp@nospam.org");
@@ -499,17 +499,17 @@ static void test_handle_user_pass(int policy_id, array_header *src_backends) {
   mark_point();
   res = proxy_reverse_handle_pass(cmd, proxy_sess, &successful,
     &block_responses);
-  fail_unless(res < 0, "Handled PASS unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Handled PASS unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_reverse_sess_exit(p);
-  fail_unless(res == 0, "Failed to exit session: %s", strerror(errno));
+  ck_assert_msg(res == 0, "Failed to exit session: %s", strerror(errno));
 
   mark_point();
   res = proxy_reverse_free(p);
-  fail_unless(res == 0, "Failed to free Reverse API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free Reverse API resources: %s",
     strerror(errno));
 
   proxy_session_free(p, proxy_sess);
@@ -731,17 +731,17 @@ START_TEST (reverse_json_parse_uris_args_test) {
   const char *path;
 
   uris = proxy_reverse_json_parse_uris(NULL, NULL, 0);
-  fail_unless(uris == NULL, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(uris == NULL, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   uris = proxy_reverse_json_parse_uris(p, NULL, 0);
-  fail_unless(uris == NULL, "Failed to handle null path argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(uris == NULL, "Failed to handle null path argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   path = "/tmp/test.dat";
   uris = proxy_reverse_json_parse_uris(NULL, path, 0);
-  fail_unless(uris == NULL, "Failed to handle null pool argument");
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(uris == NULL, "Failed to handle null pool argument");
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 }
 END_TEST
 
@@ -754,20 +754,20 @@ START_TEST (reverse_json_parse_uris_isreg_test) {
 
   path = "servers.json";
   uris = proxy_reverse_json_parse_uris(p, path, 0);
-  fail_unless(uris == NULL, "Failed to handle relative path '%s'", path);
-  fail_unless(errno == EINVAL, "Failed to set errno to EINVAL");
+  ck_assert_msg(uris == NULL, "Failed to handle relative path '%s'", path);
+  ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
 
   path = test_file;
   uris = proxy_reverse_json_parse_uris(p, path, 0);
-  fail_unless(uris == NULL, "Failed to handle nonexistent file '%s'", path);
-  fail_unless(errno == ENOENT, "Failed to set errno to ENOENT");
+  ck_assert_msg(uris == NULL, "Failed to handle nonexistent file '%s'", path);
+  ck_assert_msg(errno == ENOENT, "Failed to set errno to ENOENT");
 
   res = mkdir(test_dir, 0777);
-  fail_unless(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
     strerror(errno));
   uris = proxy_reverse_json_parse_uris(p, test_dir, 0);
-  fail_unless(uris == NULL, "Failed to handle directory path '%s'", test_dir);
-  fail_unless(errno == EISDIR, "Failed to set errno to EISDIR");
+  ck_assert_msg(uris == NULL, "Failed to handle directory path '%s'", test_dir);
+  ck_assert_msg(errno == EISDIR, "Failed to set errno to EISDIR");
 
   test_cleanup(p);
 }
@@ -785,28 +785,28 @@ START_TEST (reverse_json_parse_uris_perms_test) {
 
   perms = 0777;
   res = mkdir(test_dir, perms);
-  fail_unless(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on directory '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on directory '%s': %s",
     perms, test_dir, strerror(errno));
 
   /* First, make a world-writable file. */
   perms = 0666;
   fd = open(test_file, O_WRONLY|O_CREAT, perms);
-  fail_if(fd < 0, "Failed to create tmp file '%s': %s", test_file,
+  ck_assert_msg(fd >= 0, "Failed to create tmp file '%s': %s", test_file,
     strerror(errno));
 
   res = fchmod(fd, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on file '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on file '%s': %s",
     perms, test_file, strerror(errno));
 
   path = test_file;
   uris = proxy_reverse_json_parse_uris(p, path, 0);
-  fail_unless(uris == NULL, "Failed to handle world-writable file '%s'",
+  ck_assert_msg(uris == NULL, "Failed to handle world-writable file '%s'",
     path);
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   /* Now make the file user/group-writable only, but leave the parent
@@ -815,13 +815,13 @@ START_TEST (reverse_json_parse_uris_perms_test) {
 
   perms = 0660;
   res = fchmod(fd, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on file '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on file '%s': %s",
     perms, test_file, strerror(errno));
 
   uris = proxy_reverse_json_parse_uris(p, path, 0);
-  fail_unless(uris == NULL, "Failed to handle world-writable directory '%s'",
+  ck_assert_msg(uris == NULL, "Failed to handle world-writable directory '%s'",
     test_file);
-  fail_unless(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
+  ck_assert_msg(errno == EPERM, "Failed to set errno to EPERM, got %d (%s)",
     errno, strerror(errno));
 
   (void) close(fd);
@@ -839,14 +839,14 @@ START_TEST (reverse_json_parse_uris_empty_test) {
 
   /* Write a file with no lines. */
   res = fclose(fh);
-  fail_if(res < 0, "Failed to write file '%s': %s", test_file,
+  ck_assert_msg(res >= 0, "Failed to write file '%s': %s", test_file,
     strerror(errno));
 
   mark_point();
 
   uris = proxy_reverse_json_parse_uris(p, test_file, 0);
-  fail_unless(uris != NULL, "Did not receive parsed list as expected");
-  fail_unless(uris->nelts == 0, "Expected zero elements, found %d",
+  ck_assert_msg(uris != NULL, "Did not receive parsed list as expected");
+  ck_assert_msg(uris->nelts == 0, "Expected zero elements, found %d",
     uris->nelts);
 
   test_cleanup(p);
@@ -866,14 +866,14 @@ START_TEST (reverse_json_parse_uris_malformed_test) {
   fprintf(fh, "\"ftp://foo.bar.baz:21\" ]\n");
 
   res = fclose(fh);
-  fail_if(res < 0, "Failed to write file '%s': %s", test_file,
+  ck_assert_msg(res >= 0, "Failed to write file '%s': %s", test_file,
     strerror(errno));
 
   mark_point();
 
   uris = proxy_reverse_json_parse_uris(p, test_file, 0);
-  fail_unless(uris != NULL, "Did not receive parsed list as expected");
-  fail_unless(uris->nelts == 0, "Expected zero elements, found %d",
+  ck_assert_msg(uris != NULL, "Did not receive parsed list as expected");
+  ck_assert_msg(uris->nelts == 0, "Expected zero elements, found %d",
     uris->nelts);
 
   test_cleanup(p);
@@ -895,16 +895,16 @@ START_TEST (reverse_json_parse_uris_usable_test) {
   fprintf(fh, "\"ftp://[::1]:21212\" ]\n");
 
   res = fclose(fh);
-  fail_if(res < 0, "Failed to write file '%s': %s", test_file,
+  ck_assert_msg(res >= 0, "Failed to write file '%s': %s", test_file,
     strerror(errno));
 
   mark_point();
 
   uris = proxy_reverse_json_parse_uris(p, test_file, 0);
-  fail_unless(uris != NULL, "Did not receive parsed list as expected");
+  ck_assert_msg(uris != NULL, "Did not receive parsed list as expected");
 
   expected = 3;
-  fail_unless(uris->nelts == expected, "Expected %d elements, found %d",
+  ck_assert_msg(uris->nelts == expected, "Expected %d elements, found %d",
     expected, uris->nelts);
 
   test_cleanup(p);
@@ -916,60 +916,60 @@ START_TEST (reverse_connect_get_policy_id_test) {
   const char *policy;
 
   res = proxy_reverse_connect_get_policy_id(NULL);
-  fail_unless(res < 0, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   policy = "foo";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res < 0, "Failed to handle unsupported policy '%s'", policy);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unsupported policy '%s'", policy);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   policy = "random2";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res < 0, "Failed to handle unsupported policy '%s'", policy);
-  fail_unless(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
+  ck_assert_msg(res < 0, "Failed to handle unsupported policy '%s'", policy);
+  ck_assert_msg(errno == ENOENT, "Expected ENOENT (%d), got '%s' (%d)", ENOENT,
     strerror(errno), errno);
 
   policy = "random";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_RANDOM,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_RANDOM,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "roundrobin";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_ROUND_ROBIN,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_ROUND_ROBIN,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "shuffle";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_SHUFFLE,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_SHUFFLE,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "leastconns";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_LEAST_CONNS,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_LEAST_CONNS,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "peruser";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_PER_USER,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_PER_USER,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "pergroup";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_PER_GROUP,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_PER_GROUP,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "perhost";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_PER_HOST,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_PER_HOST,
     "Failed to handle supported policy '%s'", policy);
 
   policy = "leastresponsetime";
   res = proxy_reverse_connect_get_policy_id(policy);
-  fail_unless(res == PROXY_REVERSE_CONNECT_POLICY_LEAST_RESPONSE_TIME,
+  ck_assert_msg(res == PROXY_REVERSE_CONNECT_POLICY_LEAST_RESPONSE_TIME,
     "Failed to handle supported policy '%s'", policy);
 }
 END_TEST
@@ -978,7 +978,7 @@ START_TEST (reverse_use_proxy_auth_test) {
   int res;
 
   res = proxy_reverse_use_proxy_auth();
-  fail_unless(res == FALSE, "Expected false, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected false, got %d", res);
 }
 END_TEST
 
@@ -987,11 +987,11 @@ START_TEST (reverse_have_authenticated_test) {
   cmd_rec *cmd = NULL;
 
   res = proxy_reverse_have_authenticated(cmd);
-  fail_unless(res == FALSE, "Expected false, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected false, got %d", res);
 
   proxy_sess_state |= PROXY_SESS_STATE_BACKEND_AUTHENTICATED;
   res = proxy_reverse_have_authenticated(cmd);
-  fail_unless(res == TRUE, "Expected true, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected true, got %d", res);
 
   proxy_sess_state &= ~PROXY_SESS_STATE_BACKEND_AUTHENTICATED;
 }

--- a/t/api/session.c
+++ b/t/api/session.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2016-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2016-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -89,13 +89,13 @@ START_TEST (session_free_test) {
   int res;
 
   res = proxy_session_free(NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_session_free(p, NULL);
-  fail_unless(res < 0, "Failed to handle null session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -104,21 +104,21 @@ START_TEST (session_alloc_test) {
   struct proxy_session *proxy_sess;
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(NULL);
-  fail_unless(proxy_sess == NULL, "Failed to handle null argument");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(proxy_sess == NULL, "Failed to handle null argument");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
-  fail_unless(proxy_sess->use_ftp == TRUE, "Failed to use FTP by default");
-  fail_unless(proxy_sess->use_ssh == FALSE, "Failed to not use SSH by default");
+  ck_assert_msg(proxy_sess->use_ftp == TRUE, "Failed to use FTP by default");
+  ck_assert_msg(proxy_sess->use_ssh == FALSE, "Failed to not use SSH by default");
 
   mark_point();
   proxy_session_free(p, proxy_sess);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
 
   proxy_sess->frontend_data_conn = pr_inet_create_conn(p, -1, NULL, INPORT_ANY,
@@ -138,16 +138,16 @@ START_TEST (session_reset_dataxfer_test) {
   int res;
 
   res = proxy_session_reset_dataxfer(NULL);
-  fail_unless(res < 0, "Failed to handle null proxy_sess");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy_sess");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
 
   res = proxy_session_reset_dataxfer(proxy_sess);
-  fail_unless(res == 0, "Failed to reset proxy session dataxfer: %s",
+  ck_assert_msg(res == 0, "Failed to reset proxy session dataxfer: %s",
     strerror(errno));
 
   mark_point();
@@ -161,30 +161,30 @@ START_TEST (session_check_password_test) {
 
   mark_point();
   res = proxy_session_check_password(NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null arguments");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null arguments");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_session_check_password(p, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null user");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null user");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   user = "foo";
 
   mark_point();
   res = proxy_session_check_password(p, user, NULL);
-  fail_unless(res < 0, "Failed to handle null passwd");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null passwd");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   passwd = "bar";
 
   mark_point();
   res = proxy_session_check_password(p, user, passwd);
-  fail_unless(res < 0, "Failed to handle unknown user");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle unknown user");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -195,18 +195,18 @@ START_TEST (session_setup_env_test) {
 
   mark_point();
   res = proxy_session_setup_env(NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_session_setup_env(p, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null user");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null user");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
 
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
-  fail_unless(session.c != NULL,
+  ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));
   session.c->remote_name = pstrdup(p, "127.0.0.1");
 
@@ -214,8 +214,8 @@ START_TEST (session_setup_env_test) {
 
   mark_point();
   res = proxy_session_setup_env(p, user, flags);
-  fail_unless(res == 0, "Failed to setup environment: %s", strerror(errno));
-  fail_unless(proxy_sess_state & PROXY_SESS_STATE_PROXY_AUTHENTICATED,
+  ck_assert_msg(res == 0, "Failed to setup environment: %s", strerror(errno));
+  ck_assert_msg(proxy_sess_state & PROXY_SESS_STATE_PROXY_AUTHENTICATED,
     "Expected PROXY_AUTHENTICATED state set");
 
   proxy_sess_state &= ~PROXY_SESS_STATE_PROXY_AUTHENTICATED;
@@ -224,8 +224,8 @@ START_TEST (session_setup_env_test) {
 
   mark_point();
   res = proxy_session_setup_env(p, user, flags);
-  fail_unless(res == 0, "Failed to setup environment: %s", strerror(errno));
-  fail_unless(proxy_sess_state & PROXY_SESS_STATE_PROXY_AUTHENTICATED,
+  ck_assert_msg(res == 0, "Failed to setup environment: %s", strerror(errno));
+  ck_assert_msg(proxy_sess_state & PROXY_SESS_STATE_PROXY_AUTHENTICATED,
     "Expected PROXY_AUTHENTICATED state set");
 
   proxy_sess_state &= ~PROXY_SESS_STATE_PROXY_AUTHENTICATED;

--- a/t/api/str.c
+++ b/t/api/str.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2020 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2020-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,48 +48,48 @@ START_TEST (strnstr_test) {
 
   mark_point();
   res = proxy_strnstr(NULL, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null s1");
+  ck_assert_msg(res == NULL, "Failed to handle null s1");
 
   mark_point();
   s1 = "haystack";
   res = proxy_strnstr(s1, NULL, 0);
-  fail_unless(res == NULL, "Failed to handle null s2");
+  ck_assert_msg(res == NULL, "Failed to handle null s2");
 
   mark_point();
   s2 = "needle";
   res = proxy_strnstr(s1, s2, 0);
-  fail_unless(res == NULL, "Failed to handle zero len");
+  ck_assert_msg(res == NULL, "Failed to handle zero len");
 
   mark_point();
   len = 2;
   res = proxy_strnstr(s1, s2, len);
-  fail_unless(res == NULL, "Expected null, got %p for len %lu", res,
+  ck_assert_msg(res == NULL, "Expected null, got %p for len %lu", res,
     (unsigned long) len);
 
   mark_point();
   s1 = "  ";
   res = proxy_strnstr(s1, s2, len);
-  fail_unless(res == NULL, "Expected null, got %p for s1 spaces", res);
+  ck_assert_msg(res == NULL, "Expected null, got %p for s1 spaces", res);
 
   mark_point();
   s1 = "haystack";
   s2 = "";
   res = proxy_strnstr(s1, s2, len);
-  fail_unless(res == NULL, "Expected null, got %p for s2 empty", res);
+  ck_assert_msg(res == NULL, "Expected null, got %p for s2 empty", res);
 
   mark_point();
   s1 = "haystack";
   s2 = "haystack";
   len = 8;
   res = proxy_strnstr(s1, s2, len);
-  fail_unless(res != NULL, "Expected %p, got %p for s1 == s2", s1, res);
+  ck_assert_msg(res != NULL, "Expected %p, got %p for s1 == s2", s1, res);
 
   mark_point();
   s1 = "haystack";
   s2 = "sta";
   len = 7;
   res = proxy_strnstr(s1, s2, len);
-  fail_unless(res != NULL, "Expected %p, got %p", s1 + 3, res);
+  ck_assert_msg(res != NULL, "Expected %p, got %p", s1 + 3, res);
 }
 END_TEST
 

--- a/t/api/tls.c
+++ b/t/api/tls.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2015-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2015-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -66,11 +66,11 @@ static int create_test_dir(void) {
 
   perms = 0770;
   res = mkdir(test_dir, perms);
-  fail_unless(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
+  ck_assert_msg(res == 0, "Failed to create tmp directory '%s': %s", test_dir,
     strerror(errno));
 
   res = chmod(test_dir, perms);
-  fail_unless(res == 0, "Failed to set perms %04o on directory '%s': %s",
+  ck_assert_msg(res == 0, "Failed to set perms %04o on directory '%s': %s",
     perms, test_dir, strerror(errno));
 
   return 0;
@@ -120,12 +120,12 @@ START_TEST (tls_free_test) {
   int res;
 
   res = proxy_tls_free(NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_tls_free(p);
-  fail_unless(res == 0, "Failed to free TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free TLS API resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -135,25 +135,25 @@ START_TEST (tls_init_test) {
 
   res = proxy_tls_init(NULL, NULL, flags);
 #if defined(PR_USE_OPENSSL)
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_tls_init(p, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null tables directory");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null tables directory");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_tls_init(p, test_dir, flags);
-  fail_unless(res == 0, "Failed to init TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API resources: %s",
     strerror(errno));
 
   res = proxy_tls_free(p);
-  fail_unless(res == 0, "Failed to free TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free TLS API resources: %s",
     strerror(errno));
 #else
-  fail_unless(res == 0, "Failed to init TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API resources: %s",
     strerror(errno));
 #endif /* PR_USE_OPENSSL */
 }
@@ -163,22 +163,22 @@ START_TEST (tls_sess_free_test) {
   int res;
 
   res = proxy_tls_sess_free(NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_tls_init(p, test_dir, PROXY_DB_OPEN_FL_SKIP_VACUUM);
-  fail_unless(res == 0, "Failed to init TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API resources: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_tls_sess_free(p);
-  fail_unless(res == 0, "Failed to release TLS API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to release TLS API session resources: %s",
     strerror(errno));
 
   res = proxy_tls_free(p);
-  fail_unless(res == 0, "Failed to free TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to free TLS API resources: %s",
     strerror(errno));
 }
 END_TEST
@@ -190,45 +190,45 @@ START_TEST (tls_sess_init_test) {
 
   mark_point();
   res = proxy_tls_sess_init(NULL, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_tls_sess_init(p, NULL, flags);
-  fail_unless(res < 0, "Failed to handle null proxy_session");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null proxy_session");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   proxy_sess = (struct proxy_session *) proxy_session_alloc(p);
-  fail_unless(proxy_sess != NULL, "Failed to allocate proxy session: %s",
+  ck_assert_msg(proxy_sess != NULL, "Failed to allocate proxy session: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_tls_sess_init(p, proxy_sess, flags);
-  fail_unless(res < 0, "Failed to handle invalid SSL_CTX");
-  fail_unless(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
+  ck_assert_msg(res < 0, "Failed to handle invalid SSL_CTX");
+  ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got '%s' (%d)", EPERM,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_tls_init(p, test_dir, flags);
-  fail_unless(res == 0, "Failed to init TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API resources: %s",
     strerror(errno));
   (void) proxy_db_close(p, NULL);
 
   mark_point();
   res = proxy_tls_sess_init(p, proxy_sess, flags);
-  fail_unless(res == 0, "Failed to init TLS API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to init TLS API session resources: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_tls_sess_free(p);
-  fail_unless(res == 0, "Failed to release TLS API session resources: %s",
+  ck_assert_msg(res == 0, "Failed to release TLS API session resources: %s",
     strerror(errno));
 
   mark_point();
   res = proxy_tls_free(p);
-  fail_unless(res == 0, "Failed to release TLS API resources: %s",
+  ck_assert_msg(res == 0, "Failed to release TLS API resources: %s",
     strerror(errno));
 
   mark_point();
@@ -242,32 +242,32 @@ START_TEST (tls_using_tls_test) {
 
   tls = proxy_tls_using_tls();
 #if defined(PR_USE_OPENSSL)
-  fail_unless(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
 #else
-  fail_unless(tls == PROXY_TLS_ENGINE_OFF, "Expected TLS off, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_OFF, "Expected TLS off, got %d", tls);
 #endif /* PR_USE_OPENSSL */
 
   res = proxy_tls_set_tls(7);
 #if defined(PR_USE_OPENSSL)
-  fail_unless(res < 0, "Set TLS unexpectedly");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Set TLS unexpectedly");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   res = proxy_tls_set_tls(PROXY_TLS_ENGINE_ON);
   tls = proxy_tls_using_tls();
-  fail_unless(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_ON, "Expected TLS on, got %d", tls);
 
   res = proxy_tls_set_tls(PROXY_TLS_ENGINE_OFF);
   tls = proxy_tls_using_tls();
-  fail_unless(tls == PROXY_TLS_ENGINE_OFF, "Expected TLS off, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_OFF, "Expected TLS off, got %d", tls);
 
   res = proxy_tls_set_tls(PROXY_TLS_ENGINE_AUTO);
   tls = proxy_tls_using_tls();
-  fail_unless(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_AUTO, "Expected TLS auto, got %d", tls);
 
   res = proxy_tls_set_tls(PROXY_TLS_ENGINE_IMPLICIT);
   tls = proxy_tls_using_tls();
-  fail_unless(tls == PROXY_TLS_ENGINE_IMPLICIT, "Expected TLS implicit, got %d", tls);
+  ck_assert_msg(tls == PROXY_TLS_ENGINE_IMPLICIT, "Expected TLS implicit, got %d", tls);
 #endif /* PR_USE_OPENSSL */
 }
 END_TEST
@@ -278,14 +278,14 @@ START_TEST (tls_match_client_tls_test) {
   /* Plain FTP */
   mark_point();
   res = proxy_tls_match_client_tls();
-  fail_unless(res == 0, "Failed to match plain FTP client: %s",
+  ck_assert_msg(res == 0, "Failed to match plain FTP client: %s",
     strerror(errno));
 
   /* Explicit FTPS */
   mark_point();
   session.rfc2228_mech = "TLS";
   res = proxy_tls_match_client_tls();
-  fail_unless(res == 0, "Failed to match explicit FTPS client: %s",
+  ck_assert_msg(res == 0, "Failed to match explicit FTPS client: %s",
     strerror(errno));
 
   /* Implicit FTPS */
@@ -302,19 +302,19 @@ START_TEST (tls_set_data_prot_test) {
 
   res = proxy_tls_set_data_prot(TRUE);
 #if defined(PR_USE_OPENSSL)
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 
   res = proxy_tls_set_data_prot(FALSE);
-  fail_unless(res == TRUE, "Expected TRUE, got %d", res);
+  ck_assert_msg(res == TRUE, "Expected TRUE, got %d", res);
 #else
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   res = proxy_tls_set_data_prot(FALSE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 #endif /* PR_USE_OPENSSL */
 
   res = proxy_tls_set_data_prot(FALSE);
-  fail_unless(res == FALSE, "Expected FALSE, got %d", res);
+  ck_assert_msg(res == FALSE, "Expected FALSE, got %d", res);
 
   (void) proxy_tls_set_data_prot(TRUE);
 }

--- a/t/api/uri.c
+++ b/t/api/uri.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy testsuite
- * Copyright (c) 2012-2021 TJ Saunders <tj@castaglia.org>
+ * Copyright (c) 2012-2022 TJ Saunders <tj@castaglia.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -61,39 +61,39 @@ START_TEST (uri_parse_args_test) {
 
   mark_point();
   res = proxy_uri_parse(NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null pool");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null pool");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_uri_parse(p, NULL, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null URI");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null URI");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   uri = "foo";
   res = proxy_uri_parse(p, uri, NULL, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null scheme");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null scheme");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_uri_parse(p, uri, &scheme, NULL, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null host");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null host");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_uri_parse(p, uri, &scheme, &host, NULL, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle null port");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle null port");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI missing a colon");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI missing a colon");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -101,8 +101,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "foo:";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle unknown/unsupported scheme");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle unknown/unsupported scheme");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -110,8 +110,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "foo@:";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle illegal scheme character");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle illegal scheme character");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -119,8 +119,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "ftp:";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI lacking double slashes");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI lacking double slashes");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -128,8 +128,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "ftp:/";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI lacking double slashes");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI lacking double slashes");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -137,8 +137,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "ftp:/a";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI lacking double slashes");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI lacking double slashes");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -146,8 +146,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "ftp://";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI lacking hostname/port");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI lacking hostname/port");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -155,8 +155,8 @@ START_TEST (uri_parse_args_test) {
   port = 0;
   uri = "ftp://%2f";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to handle URI using URL encoding");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to handle URI using URL encoding");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -172,72 +172,72 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://foo";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://foo:2121";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://127.0.0.1:2121";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "127.0.0.1") == 0,
+  ck_assert_msg(strcmp(host, "127.0.0.1") == 0,
     "Expected host '%s', got '%s'", "127.0.0.1", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://[::1]:2121";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "::1") == 0,
+  ck_assert_msg(strcmp(host, "::1") == 0,
     "Expected host '%s', got '%s'", "::1", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://[::1:2121";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res < 0, "Failed to reject URI with bad IPv6 host encoding");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to reject URI with bad IPv6 host encoding");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -245,19 +245,19 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://user:password@host:21";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "host") == 0,
+  ck_assert_msg(strcmp(host, "host") == 0,
     "Expected host '%s', got '%s'", "host", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username != NULL, "Expected non-null username");
-  fail_unless(strcmp(username, "user") == 0,
+  ck_assert_msg(username != NULL, "Expected non-null username");
+  ck_assert_msg(strcmp(username, "user") == 0,
     "Expected username '%s', got '%s'", "user", username);
-  fail_unless(password != NULL, "Expected non-null password");
-  fail_unless(strcmp(password, "password") == 0,
+  ck_assert_msg(password != NULL, "Expected non-null password");
+  ck_assert_msg(strcmp(password, "password") == 0,
     "Expected password '%s', got '%s'", "password", password);
 
   mark_point();
@@ -265,19 +265,19 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://user:@host:21";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "host") == 0,
+  ck_assert_msg(strcmp(host, "host") == 0,
     "Expected host '%s', got '%s'", "host", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username != NULL, "Expected non-null username");
-  fail_unless(strcmp(username, "user") == 0,
+  ck_assert_msg(username != NULL, "Expected non-null username");
+  ck_assert_msg(strcmp(username, "user") == 0,
     "Expected username '%s', got '%s'", "user", username);
-  fail_unless(password != NULL, "Expected non-null password");
-  fail_unless(strcmp(password, "") == 0,
+  ck_assert_msg(password != NULL, "Expected non-null password");
+  ck_assert_msg(strcmp(password, "") == 0,
     "Expected password '%s', got '%s'", "", password);
 
   mark_point();
@@ -285,35 +285,35 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://user@host:21";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "host") == 0,
+  ck_assert_msg(strcmp(host, "host") == 0,
     "Expected host '%s', got '%s'", "host", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://anonymous:email@example.com@host:21";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "host") == 0,
+  ck_assert_msg(strcmp(host, "host") == 0,
     "Expected host '%s', got '%s'", "host", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username != NULL, "Expected non-null username");
-  fail_unless(strcmp(username, "anonymous") == 0,
+  ck_assert_msg(username != NULL, "Expected non-null username");
+  ck_assert_msg(strcmp(username, "anonymous") == 0,
     "Expected username '%s', got '%s'", "anonymous", username);
-  fail_unless(password != NULL, "Expected non-null password");
-  fail_unless(strcmp(password, "email@example.com") == 0,
+  ck_assert_msg(password != NULL, "Expected non-null password");
+  ck_assert_msg(strcmp(password, "email@example.com") == 0,
     "Expected password '%s', got '%s'", "email@example.com", password);
 
   mark_point();
@@ -321,19 +321,19 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://user@domain:email@example.com@host:21";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "host") == 0,
+  ck_assert_msg(strcmp(host, "host") == 0,
     "Expected host '%s', got '%s'", "host", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username != NULL, "Expected non-null username");
-  fail_unless(strcmp(username, "user@domain") == 0,
+  ck_assert_msg(username != NULL, "Expected non-null username");
+  ck_assert_msg(strcmp(username, "user@domain") == 0,
     "Expected username '%s', got '%s'", "user@domain", username);
-  fail_unless(password != NULL, "Expected non-null password");
-  fail_unless(strcmp(password, "email@example.com") == 0,
+  ck_assert_msg(password != NULL, "Expected non-null password");
+  ck_assert_msg(strcmp(password, "email@example.com") == 0,
     "Expected password '%s', got '%s'", "email@example.com", password);
 
   mark_point();
@@ -341,8 +341,8 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://host:65555";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to reject URI with too-large port");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to reject URI with too-large port");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -350,24 +350,24 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://foo:2121/home";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp") == 0,
     "Expected scheme '%s', got '%s'", "ftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftp://host:65555:foo";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to reject URI with bad port spec");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to reject URI with bad port spec");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 
   mark_point();
@@ -375,8 +375,8 @@ START_TEST (uri_parse_ftp_test) {
   port = 0;
   uri = "ftp://host:70000";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to reject URI with invalid port spec");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to reject URI with invalid port spec");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -392,48 +392,48 @@ START_TEST (uri_parse_ftps_test) {
   port = 0;
   uri = "ftps://foo";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftps") == 0,
+  ck_assert_msg(strcmp(scheme, "ftps") == 0,
     "Expected scheme '%s', got '%s'", "ftps", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 21,
+  ck_assert_msg(port == 21,
     "Expected port '%u', got '%u'", 21, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftps://foo:2121";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftps") == 0,
+  ck_assert_msg(strcmp(scheme, "ftps") == 0,
     "Expected scheme '%s', got '%s'", "ftps", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftps://foo:2121/home";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftps") == 0,
+  ck_assert_msg(strcmp(scheme, "ftps") == 0,
     "Expected scheme '%s', got '%s'", "ftps", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2121,
+  ck_assert_msg(port == 2121,
     "Expected port '%u', got '%u'", 2121, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 }
 END_TEST
 
@@ -448,48 +448,48 @@ START_TEST (uri_parse_sftp_test) {
   port = 0;
   uri = "sftp://foo";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "sftp") == 0,
+  ck_assert_msg(strcmp(scheme, "sftp") == 0,
     "Expected scheme '%s', got '%s'", "sftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 22,
+  ck_assert_msg(port == 22,
     "Expected port '%u', got '%u'", 22, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "sftp://foo:2222";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "sftp") == 0,
+  ck_assert_msg(strcmp(scheme, "sftp") == 0,
     "Expected scheme '%s', got '%s'", "sftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2222,
+  ck_assert_msg(port == 2222,
     "Expected port '%u', got '%u'", 2222, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "sftp://foo:2222/home";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "sftp") == 0,
+  ck_assert_msg(strcmp(scheme, "sftp") == 0,
     "Expected scheme '%s', got '%s'", "sftp", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 2222,
+  ck_assert_msg(port == 2222,
     "Expected port '%u', got '%u'", 2222, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 }
 END_TEST
 
@@ -504,8 +504,8 @@ START_TEST (uri_parse_http_test) {
   port = 0;
   uri = "http://host";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, NULL, NULL);
-  fail_unless(res < 0, "Failed to reject URI with unsupported scheme");
-  fail_unless(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
+  ck_assert_msg(res < 0, "Failed to reject URI with unsupported scheme");
+  ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
 }
 END_TEST
@@ -522,32 +522,32 @@ START_TEST (uri_parse_srv_test) {
   port = 0;
   uri = "ftp+srv://foo:2121/home";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp+srv") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp+srv") == 0,
     "Expected scheme '%s', got '%s'", "ftp+srv", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 0,
+  ck_assert_msg(port == 0,
     "Expected port '%u', got '%u'", 0, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftps+srv://foo.bar";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftps+srv") == 0,
+  ck_assert_msg(strcmp(scheme, "ftps+srv") == 0,
     "Expected scheme '%s', got '%s'", "ftps+srv", scheme);
-  fail_unless(strcmp(host, "foo.bar") == 0,
+  ck_assert_msg(strcmp(host, "foo.bar") == 0,
     "Expected host '%s', got '%s'", "foo.bar", host);
-  fail_unless(port == 0,
+  ck_assert_msg(port == 0,
     "Expected port '%u', got '%u'", 0, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 }
 END_TEST
 
@@ -563,32 +563,32 @@ START_TEST (uri_parse_txt_test) {
   port = 0;
   uri = "ftp+txt://foo:2121/home";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftp+txt") == 0,
+  ck_assert_msg(strcmp(scheme, "ftp+txt") == 0,
     "Expected scheme '%s', got '%s'", "ftp+txt", scheme);
-  fail_unless(strcmp(host, "foo") == 0,
+  ck_assert_msg(strcmp(host, "foo") == 0,
     "Expected host '%s', got '%s'", "foo", host);
-  fail_unless(port == 0,
+  ck_assert_msg(port == 0,
     "Expected port '%u', got '%u'", 0, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 
   mark_point();
   scheme = host = username = password = NULL;
   port = 0;
   uri = "ftps+txt://foo.bar";
   res = proxy_uri_parse(p, uri, &scheme, &host, &port, &username, &password);
-  fail_unless(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
+  ck_assert_msg(res == 0, "Expected successful parsing of URI '%s', got %s", uri,
     strerror(errno));
-  fail_unless(strcmp(scheme, "ftps+txt") == 0,
+  ck_assert_msg(strcmp(scheme, "ftps+txt") == 0,
     "Expected scheme '%s', got '%s'", "ftps+txt", scheme);
-  fail_unless(strcmp(host, "foo.bar") == 0,
+  ck_assert_msg(strcmp(host, "foo.bar") == 0,
     "Expected host '%s', got '%s'", "foo.bar", host);
-  fail_unless(port == 0,
+  ck_assert_msg(port == 0,
     "Expected port '%u', got '%u'", 0, port);
-  fail_unless(username == NULL, "Expected null username, got '%s'", username);
-  fail_unless(password == NULL, "Expected null password, got '%s'", password);
+  ck_assert_msg(username == NULL, "Expected null username, got '%s'", username);
+  ck_assert_msg(password == NULL, "Expected null password, got '%s'", password);
 }
 END_TEST
 


### PR DESCRIPTION
…` assertion APIs.