### PR TITLE
Clean up trailing whitespace.

### DIFF
--- a/lib/proxy/conn.c
+++ b/lib/proxy/conn.c
@@ -371,7 +371,7 @@ const struct proxy_conn *proxy_conn_create(pool *p, const char *uri,
   memset(hostport, '\0', sizeof(hostport));
   snprintf(hostport, sizeof(hostport)-1, "%s:%u", remote_host, remote_port);
 
-  pconn_pool = pr_pool_create_sz(p, 128); 
+  pconn_pool = pr_pool_create_sz(p, 128);
   pr_pool_tag(pconn_pool, "proxy connection pool");
 
   pconn = pcalloc(pconn_pool, sizeof(struct proxy_conn));
@@ -559,7 +559,7 @@ const char *proxy_conn_get_password(const struct proxy_conn *pconn) {
     errno = EINVAL;
     return NULL;
   }
-  
+
   return pconn->pconn_password;
 }
 

--- a/lib/proxy/db.c
+++ b/lib/proxy/db.c
@@ -368,17 +368,17 @@ int proxy_db_prepare_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt) {
     pr_trace_msg(trace_channel, 4,
       "error stashing prepared statement '%s': %s", stmt, strerror(xerrno));
     errno = xerrno;
-    return -1; 
+    return -1;
   }
 
-  return 0; 
+  return 0;
 }
 
 int proxy_db_bind_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt,
     int idx, int type, void *data, int datalen) {
   sqlite3_stmt *pstmt;
   int res;
- 
+
   if (p == NULL ||
       dbh == NULL ||
       stmt == NULL) {
@@ -537,7 +537,7 @@ int proxy_db_finish_stmt(pool *p, struct proxy_dbh *dbh, const char *stmt) {
     return -1;
   }
 
-  (void) pr_table_remove(dbh->prepared_stmts, stmt, NULL); 
+  (void) pr_table_remove(dbh->prepared_stmts, stmt, NULL);
   return 0;
 }
 

--- a/lib/proxy/forward.c
+++ b/lib/proxy/forward.c
@@ -674,10 +674,10 @@ static int forward_handle_user_passthru(cmd_rec *cmd,
 
   /* XXX TODO: Concatenate the banner from the connect with the USER response
    * message here, and send the entire kit to the frontend client, e.g.:
-   * 
+   *
    *  Name (gatekeeper:you): anonymous@ftp.uu.net
    *  331-(----GATEWAY CONNECTED TO ftp.uu.net----)
-   *  331-(220 ftp.uu.net FTP server (SunOS 4.1) ready. 
+   *  331-(220 ftp.uu.net FTP server (SunOS 4.1) ready.
    *  331 Guest login ok, send ident as password.
    *  Password: ######
    *  230 Guest login ok, access restrictions apply.
@@ -694,7 +694,7 @@ static int forward_handle_user_passthru(cmd_rec *cmd,
     return -1;
   }
 
-  return 1; 
+  return 1;
 }
 
 static int forward_handle_user_proxyuserwithproxyauth(cmd_rec *cmd,

--- a/lib/proxy/ftp/ctrl.c
+++ b/lib/proxy/ftp/ctrl.c
@@ -224,7 +224,7 @@ pr_response_t *proxy_ftp_ctrl_recv_resp(pool *p, conn_t *ctrl_conn,
       if (buf[3] == '-') {
         multiline = TRUE;
       }
- 
+
       count++;
       resp = (pr_response_t *) pcalloc(p, sizeof(pr_response_t));
 

--- a/lib/proxy/ftp/dirlist.c
+++ b/lib/proxy/ftp/dirlist.c
@@ -842,8 +842,8 @@ struct proxy_dirlist_fileinfo *proxy_ftp_dirlist_fileinfo_from_unix(pool *p,
       "malformed Unix text (expected space after nlink): '%*s'",
       (int) textlen, text);
     errno = EINVAL;
-    return NULL; 
-  }    
+    return NULL;
+  }
 
   ptr += 1;
 
@@ -879,7 +879,7 @@ struct proxy_dirlist_fileinfo *proxy_ftp_dirlist_fileinfo_from_unix(pool *p,
     pr_trace_msg(trace_channel, 3,
       "malformed Unix text (expected group with '%*s'): '%*s'", (int) buflen,
       buf, (int) textlen, text);
-      
+
     errno = xerrno;
     return NULL;
   }
@@ -930,7 +930,7 @@ struct proxy_dirlist_fileinfo *proxy_ftp_dirlist_fileinfo_from_unix(pool *p,
       (int) textlen, text);
     errno = EINVAL;
     return NULL;
-  } 
+  }
 
   ptr += 1;
 
@@ -939,15 +939,15 @@ struct proxy_dirlist_fileinfo *proxy_ftp_dirlist_fileinfo_from_unix(pool *p,
   buf = pstrndup(p, ptr, buflen);
   if (get_unix_timestamp(p, buf, buflen, pdf->tm, tm->tm_year) < 0) {
     int xerrno = errno;
-  
+
     pr_trace_msg(trace_channel, 3,
       "malformed Unix text (expected timestamp with '%*s'): '%*s'",
       (int) buflen, buf, (int) textlen, text);
-  
+
     errno = xerrno;
     return NULL;
   }
-    
+
   ptr += buflen;
   if (strncmp(ptr, " ", 1) != 0) {
     pr_trace_msg(trace_channel, 3,

--- a/lib/proxy/ftp/msg.c
+++ b/lib/proxy/ftp/msg.c
@@ -208,7 +208,7 @@ const pr_netaddr_t *proxy_ftp_msg_parse_addr(pool *p, const char *msg,
   addrlen += 7;
 #endif /* PR_USE_IPV6 */
 
-  addr_buf = pcalloc(p, addrlen); 
+  addr_buf = pcalloc(p, addrlen);
 
 #ifdef PR_USE_IPV6
   if (pr_netaddr_use_ipv6()) {

--- a/lib/proxy/ftp/sess.c
+++ b/lib/proxy/ftp/sess.c
@@ -80,7 +80,7 @@ static int parse_feat(pool *p, const char *feat, array_header **res) {
     if (len > 0) {
       *((char **) push_array(vals)) = pstrndup(p, ptr, len);
     }
- 
+
     ptr = ptr2;
     while (*ptr == ';') {
       pr_signals_handle();

--- a/lib/proxy/ftp/xfer.c
+++ b/lib/proxy/ftp/xfer.c
@@ -453,7 +453,7 @@ const pr_netaddr_t *proxy_ftp_xfer_prepare_passive(int policy_id, cmd_rec *cmd,
     case PR_CMD_EPSV_ID:
       passive_respcode = R_229;
       break;
-  } 
+  }
 
   res = proxy_ftp_ctrl_send_cmd(cmd->tmp_pool, proxy_sess->backend_ctrl_conn,
     pasv_cmd);

--- a/lib/proxy/netio.c
+++ b/lib/proxy/netio.c
@@ -163,7 +163,7 @@ pr_netio_t *proxy_netio_unset(int strm_type, const char *fn) {
     default:
       break;
   }
- 
+
   return netio;
 }
 
@@ -264,7 +264,7 @@ int proxy_netio_postopen(pr_netio_stream_t *nstrm) {
   res = pr_netio_postopen(nstrm);
   xerrno = errno;
   proxy_netio_set(nstrm->strm_type, curr_netio);
- 
+
   errno = xerrno;
   return res;
 }

--- a/lib/proxy/reverse.c
+++ b/lib/proxy/reverse.c
@@ -540,7 +540,7 @@ static array_header *reverse_db_pername_backends_by_json(pool *p,
     if (backends->nelts == 0) {
       pr_trace_msg(trace_channel, 3,
         "no usable URLs found in ProxyReverseServers file '%s', ignoring",
-        path); 
+        path);
 
     } else {
       if (file_backends == NULL) {
@@ -845,7 +845,7 @@ static int reverse_try_connect(pool *p, struct proxy_session *proxy_sess,
           strerror(errno));
       }
     }
- 
+
     errno = xerrno;
     return -1;
   }
@@ -1410,7 +1410,7 @@ static pr_json_array_t *read_json_array(pool *p, pr_fh_t *fh, off_t filesz) {
 
     /* Short read: advance the buffer, decrement the length, and read more. */
     buf += res;
-    len -= res; 
+    len -= res;
 
     pr_signals_handle();
     res = pr_fsio_read(fh, buf, len);
@@ -1834,7 +1834,7 @@ static int send_pass(struct proxy_session *proxy_sess, cmd_rec *cmd,
 
     proxy_sess_state |= PROXY_SESS_STATE_BACKEND_AUTHENTICATED;
     clear_user_creds();
-    pr_timer_remove(PR_TIMER_LOGIN, ANY_MODULE); 
+    pr_timer_remove(PR_TIMER_LOGIN, ANY_MODULE);
   }
 
   res = proxy_ftp_ctrl_send_resp(cmd->tmp_pool, proxy_sess->frontend_ctrl_conn,

--- a/lib/proxy/reverse/db.c
+++ b/lib/proxy/reverse/db.c
@@ -1341,7 +1341,7 @@ static const struct proxy_conn *reverse_db_perhost_next(pool *p,
     /* This can happen the very first time; perform an on-demand discovery
      * of the backends for this host, and try again.
      */
- 
+
     pconn = reverse_db_perhost_init(p, dbh, vhost_id, db_backends, addr);
     if (pconn == NULL) {
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -1408,7 +1408,7 @@ static int reverse_db_perhost_used(pool *p, struct proxy_dbh *dbh,
   if (res < 0) {
     return -1;
   }
- 
+
   results = proxy_db_exec_prepared_stmt(p, dbh, stmt, &errstr);
   if (results == NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -1437,7 +1437,7 @@ static int reverse_db_policy_init(pool *p, void *dbh, int policy_id,
       break;
 
     case PROXY_REVERSE_CONNECT_POLICY_ROUND_ROBIN: {
-      int backend_id = 0; 
+      int backend_id = 0;
 
       if (backends != NULL) {
         backend_id = backends->nelts-1;
@@ -1589,7 +1589,7 @@ static const struct proxy_conn *reverse_db_policy_next_backend(pool *p,
           pr_netaddr_get_ipstr(session.c->remote_addr));
       }
       break;
- 
+
     default:
       errno = ENOSYS;
       return NULL;

--- a/lib/proxy/reverse/redis.c
+++ b/lib/proxy/reverse/redis.c
@@ -274,7 +274,7 @@ static long reverse_redis_shuffle_next(pool *p, pr_redis_t *redis,
 
     count = 0;
   }
- 
+
   if (count == 0) {
     res = reverse_redis_shuffle_init(p, redis, vhost_id, redis_backends);
     xerrno = errno;
@@ -988,7 +988,7 @@ static const struct proxy_conn *reverse_redis_policy_next_backend(pool *p,
           pr_netaddr_get_ipstr(session.c->remote_addr));
       }
       break;
- 
+
     default:
       errno = ENOSYS;
       return NULL;
@@ -1122,7 +1122,7 @@ static void *reverse_redis_init(pool *p, const char *tables_path, int flags) {
   }
 
   (void) pr_redis_conn_set_namespace(redis, &proxy_module, redis_prefix,
-    redis_prefixsz); 
+    redis_prefixsz);
   return redis;
 }
 

--- a/lib/proxy/session.c
+++ b/lib/proxy/session.c
@@ -229,7 +229,7 @@ int proxy_session_setup_env(pool *p, const char *user, int flags) {
       errno = EPERM;
       return -1;
     }
-  
+
     session.user = pstrdup(p, pw->pw_name);
     session.group = pstrdup(p, pr_auth_gid2name(p, pw->pw_gid));
 
@@ -243,7 +243,7 @@ int proxy_session_setup_env(pool *p, const char *user, int flags) {
      * be?  Kept as is?
      */
   }
- 
+
   if (session.gids == NULL &&
       session.groups == NULL) {
     res = pr_auth_getgroups(p, session.user, &session.gids, &session.groups);

--- a/lib/proxy/ssh/agent.c
+++ b/lib/proxy/ssh/agent.c
@@ -325,7 +325,7 @@ int proxy_ssh_agent_get_keys(pool *p, const char *agent_path,
 
     key->key_data = key_data;
     key->key_datalen = key_datalen;
-    key->agent_path = pstrdup(p, agent_path); 
+    key->agent_path = pstrdup(p, agent_path);
 
     *((struct agent_key **) push_array(key_list)) = key;
   }
@@ -394,6 +394,6 @@ const unsigned char *proxy_ssh_agent_sign_data(pool *p, const char *agent_path,
   len = proxy_ssh_msg_read_int(p, &resp, &resplen, sig_datalen);
   len = proxy_ssh_msg_read_data(p, &resp, &resplen, *sig_datalen, &sig_data);
 
-  return sig_data; 
+  return sig_data;
 }
 #endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/auth.c
+++ b/lib/proxy/ssh/auth.c
@@ -314,19 +314,19 @@ static int write_userauth_hostbased(struct proxy_ssh_packet *pkt,
   } else if (proxy_ssh_keys_have_hostkey(PROXY_SSH_KEY_ECDSA_521) == 0) {
     use_hostkey_type = PROXY_SSH_KEY_ECDSA_521;
     hostkey_algo = "ecdsa-sha2-nistp521";
-  
+
   } else if (proxy_ssh_keys_have_hostkey(PROXY_SSH_KEY_ECDSA_384) == 0) {
     use_hostkey_type = PROXY_SSH_KEY_ECDSA_384;
     hostkey_algo = "ecdsa-sha2-nistp384";
-  
+
   } else if (proxy_ssh_keys_have_hostkey(PROXY_SSH_KEY_ECDSA_256) == 0) {
     use_hostkey_type = PROXY_SSH_KEY_ECDSA_256;
     hostkey_algo = "ecdsa-sha2-nistp256";
-  
+
   } else if (proxy_ssh_keys_have_hostkey(PROXY_SSH_KEY_RSA) == 0) {
     use_hostkey_type = PROXY_SSH_KEY_RSA;
     hostkey_algo = "ssh-rsa";
-  
+
   } else if (proxy_ssh_keys_have_hostkey(PROXY_SSH_KEY_DSA) == 0) {
     use_hostkey_type = PROXY_SSH_KEY_DSA;
     hostkey_algo = "ssh-dss";

--- a/lib/proxy/ssh/cipher.c
+++ b/lib/proxy/ssh/cipher.c
@@ -116,7 +116,7 @@ static void switch_read_cipher(void) {
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
         "error clearing cipher context: %s", proxy_ssh_crypto_get_errors());
     }
- 
+
     read_blockszs[read_cipher_idx] = PROXY_SSH_CIPHER_DEFAULT_BLOCK_SZ;
 
     /* Now we can switch the index. */

--- a/lib/proxy/ssh/compress.c
+++ b/lib/proxy/ssh/compress.c
@@ -89,7 +89,7 @@ static void switch_read_compress(int flags) {
   /* First we can free up the read stream, kept from rekeying. */
   if (comp->use_zlib == flags &&
       comp->stream_ready == TRUE) {
-  
+
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "done decompressing data: decompressed %" PR_LU " bytes to %" PR_LU
       " bytes of data (%.2f)", (pr_off_t) stream->total_in,
@@ -112,16 +112,16 @@ static void switch_read_compress(int flags) {
 }
 
 static void switch_write_compress(int flags) {
-  struct proxy_ssh_compress *comp; 
+  struct proxy_ssh_compress *comp;
   z_stream *stream;
- 
+
   comp = &(write_compresses[write_comp_idx]);
   stream = &(write_streams[write_comp_idx]);
- 
+
   /* First we can free up the write stream, kept from rekeying. */
   if (comp->use_zlib == flags &&
       comp->stream_ready == TRUE) {
- 
+
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "done compressing data: compressed %" PR_LU " bytes to %" PR_LU
       " bytes of data (%.2f)", (pr_off_t) stream->total_in,
@@ -364,7 +364,7 @@ int proxy_ssh_compress_set_write_algo(pool *p, const char *algo) {
 
   if (write_compresses[idx].stream_ready) {
     /* If we have an existing stream, it means that we are currently
-     * rekeying. 
+     * rekeying.
      */
     idx = get_next_write_index();
   }

--- a/lib/proxy/ssh/crypto.c
+++ b/lib/proxy/ssh/crypto.c
@@ -1126,7 +1126,7 @@ const char *proxy_ssh_crypto_get_kexinit_cipher_list(pool *p) {
                   ) {
                 res = pstrcat(p, res, *res ? "," : "",
                   pstrdup(p, ciphers[j].name), NULL);
-       
+
               } else {
                 pr_trace_msg(trace_channel, 3,
                   "unable to use '%s' cipher: Unsupported by OpenSSL",
@@ -1182,7 +1182,7 @@ const char *proxy_ssh_crypto_get_kexinit_cipher_list(pool *p) {
               res = pstrcat(p, res, *res ? "," : "",
                 pstrdup(p, ciphers[i].name), NULL);
 
-            } else {       
+            } else {
               pr_trace_msg(trace_channel, 3,
                 "unable to use '%s' cipher: Unsupported by OpenSSL",
                 ciphers[i].name);

--- a/lib/proxy/ssh/db.c
+++ b/lib/proxy/ssh/db.c
@@ -79,7 +79,7 @@ static int ssh_db_add_hostkey(pool *p, void *dsh, unsigned int vhost_id,
 
   res = proxy_db_bind_stmt(p, dbh, stmt, 4, PROXY_DB_BIND_TYPE_BLOB,
     (void *) hostkey_data, (int) hostkey_datalen);
-  if (res < 0) { 
+  if (res < 0) {
     return -1;
   }
 

--- a/lib/proxy/ssh/interop.c
+++ b/lib/proxy/ssh/interop.c
@@ -96,12 +96,12 @@ static struct proxy_ssh_version_pattern known_versions[] = {
   { "^2\\.0\\.11.*|"
     "^2\\.0\\.12.*",		PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO_IN_DSA_SIG|
 				PROXY_SSH_FEAT_SERVICE_IN_PUBKEY_SIG|
-    				PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO| 
+    				PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO|
 				PROXY_SSH_FEAT_MAC_LEN,			NULL },
 
   { "^2\\.0\\..*",		PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO_IN_DSA_SIG|
 				PROXY_SSH_FEAT_SERVICE_IN_PUBKEY_SIG|
-    				PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO| 
+    				PROXY_SSH_FEAT_HAVE_PUBKEY_ALGO|
 				PROXY_SSH_FEAT_CIPHER_USE_K|
 				PROXY_SSH_FEAT_MAC_LEN,			NULL },
 
@@ -265,14 +265,14 @@ int proxy_ssh_interop_handle_version(pool *p,
 
         if (pessimistic_newkeys == TRUE) {
           default_flags |= PROXY_SSH_FEAT_PESSIMISTIC_NEWKEYS;
-        } 
+        }
       }
 
       /* Once we're done, we can destroy the table. */
       (void) pr_table_empty(tab);
       (void) pr_table_free(tab);
       c->argv[2] = NULL;
- 
+
     } else {
       pr_trace_msg(trace_channel, 18,
         "server version '%s' did not match ProxySFTPServerMatch regex '%s'",

--- a/lib/proxy/ssh/kex.c
+++ b/lib/proxy/ssh/kex.c
@@ -191,7 +191,7 @@ static const char *dh_group1_str =
   "4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
   "EE386BFB5A899FA5AE9F24117C4B1FE649286651ECE65381FFFFFFFFFFFFFFFF";
 
-static const char *dh_group14_str = 
+static const char *dh_group14_str =
   "FFFFFFFFFFFFFFFFC90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74"
   "020BBEA63B139B22514A08798E3404DDEF9519B3CD3A431B302B0A6DF25F1437"
   "4FE1356D6D51C245E485B576625E7EC6F44C42E9A637ED6B0BFF5CB6F406B7ED"
@@ -564,7 +564,7 @@ static const unsigned char *calculate_gex_h(pool *p, struct proxy_ssh_kex *kex,
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
   DH_get0_key(kex->dh, &dh_pub_key, NULL);
-#else 
+#else
   dh_pub_key = kex->dh->pub_key;
 #endif /* prior to OpenSSL-1.1.0 */
   len += proxy_ssh_msg_write_mpint(&buf, &buflen, dh_pub_key);
@@ -1556,7 +1556,7 @@ static const char *get_preferred_name(pool *p, const char *names) {
 
   /* Advance to the first comma, or NUL. */
   for (i = 0; names[i] && names[i] != ','; i++);
-  
+
   if (names[i] == ',' ||
       names[i] == '\0') {
     char *pref;
@@ -2981,7 +2981,7 @@ static struct proxy_ssh_packet *read_kex_packet(pool *p,
     ntypes, ntypes != 1 ? "types" : "type");
 
   allowed_types = make_array(p, 1, sizeof(char));
- 
+
   va_start(ap, ntypes);  
 
   while (ntypes-- > 0) {
@@ -3139,7 +3139,7 @@ static int read_dh_reply(struct proxy_ssh_packet *pkt,
     xerrno = errno;
     DH_free(kex->dh);
     kex->dh = NULL;
-   
+
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error handling server host key: %s", strerror(xerrno));
     errno = xerrno;
@@ -3151,7 +3151,7 @@ static int read_dh_reply(struct proxy_ssh_packet *pkt,
   if (have_good_dh(kex->dh, server_pub_key) < 0) {
     DH_free(kex->dh);
     kex->dh = NULL;
-   
+
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "invalid server public DH key");
     return -1;
@@ -3920,7 +3920,7 @@ static int read_ecdh_reply(struct proxy_ssh_packet *pkt,
     xerrno = errno;
     EC_KEY_free(kex->ec);
     kex->ec = NULL;
-  
+
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error handling server host key: %s", strerror(xerrno));
     errno = xerrno;
@@ -4133,7 +4133,7 @@ static int read_kexrsa_pubkey(struct proxy_ssh_packet *pkt,
       "unsupported key type received: %s",
       key_type != NULL ? key_type : "(nil)");
     return -1;
-  } 
+  }
 
   proxy_ssh_msg_read_mpint(pkt->pool, &buf, &buflen, &rsa_e);
   proxy_ssh_msg_read_mpint(pkt->pool, &buf, &buflen, &rsa_n);
@@ -5093,7 +5093,7 @@ int proxy_ssh_kex_sess_init(pool *p, struct proxy_ssh_datastore *ds,
 
   kex_ds = ds;
   kex_verify_hostkeys = verify_hostkeys;
- 
+
   return 0;
 }
 
@@ -5176,7 +5176,7 @@ int proxy_ssh_kex_send_first_kexinit(pool *p,
   }
 
   /* We have just connected to the server.  We want to send our version
-   * ID string _and_ the KEXINIT in the same TCP packet, and save a 
+   * ID string _and_ the KEXINIT in the same TCP packet, and save a
    * TCP round trip (one TCP ACK for both messages, rather than one ACK
    * per message).  The packet API will automatically send the version
    * ID string along with the first packet we send; we just have to
@@ -5184,7 +5184,7 @@ int proxy_ssh_kex_send_first_kexinit(pool *p,
    */
   kex_first_kex = create_kex(kex_pool);
 
-  pkt = proxy_ssh_packet_create(kex_pool); 
+  pkt = proxy_ssh_packet_create(kex_pool);
   res = write_kexinit(pkt, kex_first_kex);
   if (res < 0) {
     destroy_kex(kex_first_kex);

--- a/lib/proxy/ssh/keys.c
+++ b/lib/proxy/ssh/keys.c
@@ -256,7 +256,7 @@ static void prepare_provider_fds(int stdout_fd, int stderr_fd) {
      */
     nfiles = 255;
   }
- 
+
   /* Close the "non-standard" file descriptors. */
   for (i = 3; i < nfiles; i++) {
     pr_signals_handle();
@@ -1148,11 +1148,11 @@ static void scrub_pkeys(void) {
   if (pkey_list == NULL) {
     return;
   }
- 
+
   /* Scrub and free all passphrases in memory. */
   pr_log_debug(DEBUG5, MOD_PROXY_VERSION ": scrubbing %u %s from memory",
     npkeys, npkeys != 1 ? "passphrases" : "passphrase");
- 
+
   for (k = pkey_list; k; k = k->next) {
     if (k->client_pkey != NULL) {
       pr_memscrub(k->client_pkey, k->pkeysz);
@@ -1776,7 +1776,7 @@ static int validate_ecdsa_private_key(const EC_KEY *ec) {
       "error getting the EC group order: %s", proxy_ssh_crypto_get_errors());
     BN_CTX_free(bn_ctx);
     errno = EPERM;
-    return -1; 
+    return -1;
   }
 
   priv_key_nbits = BN_num_bits(EC_KEY_get0_private_key(ec));
@@ -1788,7 +1788,7 @@ static int validate_ecdsa_private_key(const EC_KEY *ec) {
       "least %d bits", priv_key_nbits, ec_order_nbits);
     BN_CTX_free(bn_ctx);
     errno = EACCES;
-    return -1; 
+    return -1;
   }
 
   /* Ensure that the private key < (EC order - 1). */
@@ -1799,7 +1799,7 @@ static int validate_ecdsa_private_key(const EC_KEY *ec) {
       proxy_ssh_crypto_get_errors());
     BN_CTX_free(bn_ctx);
     errno = EPERM;
-    return -1; 
+    return -1;
   }
 
   if (BN_cmp(EC_KEY_get0_private_key(ec), bn_tmp) >= 0) {
@@ -1808,7 +1808,7 @@ static int validate_ecdsa_private_key(const EC_KEY *ec) {
       "rejecting");
     BN_CTX_free(bn_ctx);
     errno = EACCES;
-    return -1; 
+    return -1;
   }
 
   BN_CTX_free(bn_ctx);
@@ -1935,7 +1935,7 @@ int proxy_ssh_keys_validate_ecdsa_params(const EC_GROUP *group,
     errno = EACCES;
     return -1;
   }
- 
+
   /* A BN_CTX is like our pools; we allocate one, use it to get any
    * number of BIGNUM variables, and only have free up the BN_CTX when
    * we're done, rather than all of the individual BIGNUMs.
@@ -2000,7 +2000,7 @@ int proxy_ssh_keys_validate_ecdsa_params(const EC_GROUP *group,
 
   /* Ensure that the following are both true:
    *
-   *  log2(X coord) > log2(EC order)/2 
+   *  log2(X coord) > log2(EC order)/2
    *  log2(Y coord) > log2(EC order)/2
    */
 
@@ -2063,7 +2063,7 @@ int proxy_ssh_keys_validate_ecdsa_params(const EC_GROUP *group,
    *
    *  X < order - 1
    *  Y < order - 1
-   */ 
+   */
 
   bn_tmp = BN_CTX_get(bn_ctx);
   if (bn_tmp == NULL) {
@@ -2836,11 +2836,11 @@ static int handle_hostkey(pool *p, EVP_PKEY *pkey,
             ecdsa384_hostkey->key_datalen = 0;
             ecdsa384_hostkey->file_path = NULL;
             ecdsa384_hostkey->agent_path = NULL;
-          
+
           } else {
             ecdsa384_hostkey = pcalloc(p, sizeof(struct proxy_ssh_hostkey));
-          } 
-          
+          }
+
           ecdsa384_hostkey->key_type = PROXY_SSH_KEY_ECDSA_384;
           ecdsa384_hostkey->pkey = pkey;
           ecdsa384_hostkey->key_data = key_data;
@@ -2869,11 +2869,11 @@ static int handle_hostkey(pool *p, EVP_PKEY *pkey,
             ecdsa521_hostkey->key_datalen = 0;
             ecdsa521_hostkey->file_path = NULL;
             ecdsa521_hostkey->agent_path = NULL;
-          
+
           } else {
             ecdsa521_hostkey = pcalloc(p, sizeof(struct proxy_ssh_hostkey));
-          } 
-          
+          }
+
           ecdsa521_hostkey->key_type = PROXY_SSH_KEY_ECDSA_521;
           ecdsa521_hostkey->pkey = pkey;
           ecdsa521_hostkey->key_data = key_data;
@@ -2937,7 +2937,7 @@ static int load_agent_hostkeys(pool *p, const char *path) {
   int accepted_nkeys = 0, res;
   array_header *key_list;
 
-  key_list = make_array(p, 0, sizeof(struct agent_key *));  
+  key_list = make_array(p, 0, sizeof(struct agent_key *));
 
   res = proxy_ssh_agent_get_keys(p, path, key_list);
   if (res < 0) {
@@ -5489,7 +5489,7 @@ int proxy_ssh_keys_verify_signed_data(pool *p, const char *pubkey_algo,
     res = rsa_sha256_verify_signed_data(p, pkey, signature, signature_len,
       sig_data, sig_datalen);
 #endif /* HAVE_SHA256_OPENSSL */
-  
+
 #if defined(HAVE_SHA512_OPENSSL)
   } else if (strcmp(sig_type, "rsa-sha2-512") == 0) {
     res = rsa_sha512_verify_signed_data(p, pkey, signature, signature_len,

--- a/lib/proxy/ssh/mac.c
+++ b/lib/proxy/ssh/mac.c
@@ -127,7 +127,7 @@ static void switch_read_mac(void) {
       proxy_ssh_umac128_reset(umac_read_ctxs[read_mac_idx]);
     }
 
-    mac_blockszs[read_mac_idx] = 0; 
+    mac_blockszs[read_mac_idx] = 0;
 
     /* Now we can switch the index. */
     if (read_mac_idx == 1) {
@@ -453,7 +453,7 @@ static int set_mac_key(struct proxy_ssh_mac *mac, const EVP_MD *md,
   uint32_t key_len = 0;
 
   key_sz = proxy_ssh_crypto_get_size(EVP_MD_block_size(mac->digest),
-    EVP_MD_size(md)); 
+    EVP_MD_size(md));
   if (key_sz == 0) {
     if (strcmp(mac->algo, "none") == 0) {
       return 0;

--- a/lib/proxy/ssh/packet.c
+++ b/lib/proxy/ssh/packet.c
@@ -95,7 +95,7 @@ int proxy_ssh_packet_conn_mpoll(conn_t *frontend_conn, conn_t *backend_conn,
      */
 
     if (server_alive_interval > 0 &&
-        (!(proxy_sess_state & PROXY_SESS_STATE_SSH_REKEYING) && 
+        (!(proxy_sess_state & PROXY_SESS_STATE_SSH_REKEYING) &&
          (proxy_sess_state & PROXY_SESS_STATE_SSH_HAVE_AUTH))) {
       timeout_sec = server_alive_interval;
       using_server_alive = TRUE;
@@ -811,7 +811,7 @@ static int read_packet_payload(conn_t *conn, struct proxy_ssh_packet *pkt,
   if (res < 0) {
     return res;
   }
- 
+
   len = res;
 
   /* For ETM modes, we do NOT want to decrypt the data yet; we need to read/
@@ -1178,7 +1178,7 @@ int proxy_ssh_packet_read(conn_t *conn, struct proxy_ssh_packet *pkt) {
      * we do NOT check that the packet length is sane here; we have to
      * wait until the MAC check succeeds.
      */
- 
+
     /* Note: Checking for the RFC4253-recommended minimum packet length
      * of 16 bytes causes KEX to fail (the NEWKEYS packet is 12 bytes).
      * Thus that particular check is omitted.
@@ -2082,7 +2082,7 @@ int proxy_ssh_packet_handle(void *data) {
             "Time before first SSH key exchange: %lu ms", elapsed_ms);
         }
       }
- 
+
       proxy_sess_state |= PROXY_SESS_STATE_SSH_REKEYING;
 
       /* Clear any current "have KEX" state. */

--- a/lib/proxy/ssh/redis.c
+++ b/lib/proxy/ssh/redis.c
@@ -99,7 +99,7 @@ static int ssh_redis_update_hostkey(pool *p, void *dsh, unsigned int vhost_id,
   res = pr_redis_hash_set(redis, &proxy_module, key, redis_blob_field,
     (void *) data, field_len);
   xerrno = errno;
-  
+
   if (res < 0) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "error setting value for field '%s' in Redis hash '%s': %s",

--- a/lib/proxy/ssh/utf8.c
+++ b/lib/proxy/ssh/utf8.c
@@ -58,7 +58,7 @@ static int utf8_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
 #if defined(LINUX) || defined(DARWIN6) || defined(DARWIN7) || \
     defined(DARWIN8) || defined(DARWIN9) || defined(DARWIN10) || \
     defined(DARWIN11) || defined(DARWIN12)
- 
+
     nconv = iconv(conv, (char **) &inbuf, inbuflen, &outbuf, outbuflen);
 #else
     nconv = iconv(conv, &inbuf, inbuflen, &outbuf, outbuflen);
@@ -180,7 +180,7 @@ int proxy_ssh_utf8_init(void) {
       "to '%s': %s", local_charset, "UTF-8", strerror(errno));
     return -1;
   }
- 
+
   decode_conv = iconv_open(local_charset, "UTF-8");
   if (decode_conv == (iconv_t) -1) {
     int xerrno = errno;
@@ -244,7 +244,7 @@ char *proxy_ssh_utf8_decode_text(pool *p, const char *text) {
       register unsigned int i;
       unsigned char *raw_text;
       size_t len, raw_len;
-      
+
       len = strlen(text);
       raw_len = (len * 5) + 1;
       raw_text = pcalloc(p, raw_len + 1);

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -197,7 +197,7 @@ static char *tls_x509_name_oneline(X509_NAME *x509_name) {
   char *data = NULL;
   long datalen = 0;
   int ok;
-  
+
   ok = X509_NAME_print_ex(mem, x509_name, 0, XN_FLAG_ONELINE);
   if (ok) {
     datalen = BIO_get_mem_data(mem, &data);
@@ -653,7 +653,7 @@ static ssize_t tls_write(SSL *ssl, const void *buf, size_t len,
     }
 
     (void) pr_gettimeofday_millis(&now);
-    
+
     wbio = SSL_get_wbio(ssl);
 
     if (adaptive_bytes_written_count != NULL) {
@@ -1272,7 +1272,7 @@ static int tls_get_cached_sess(pool *p, SSL *ssl, const char *host, int port) {
       pr_trace_msg(trace_channel, 9,
         "error getting cached session using key '%s': %s", sess_key,
         strerror(errno));
-    } 
+    }
 
     return 0;
   }
@@ -1629,13 +1629,14 @@ static int tls_connect(conn_t *conn, const char *host_name,
 static int tls_seed_prng(void) {
   char *heapdata, stackdata[1024];
   FILE *fp = NULL;
-  pid_t pid; 
+  pid_t pid;
   struct timeval tv;
- 
+
 #if OPENSSL_VERSION_NUMBER >= 0x00905100L
-  if (RAND_status() == 1)
+  if (RAND_status() == 1) {
     /* PRNG already well-seeded. */
     return 0;
+  }
 #endif
 
   pr_log_debug(DEBUG9, MOD_PROXY_VERSION

--- a/lib/proxy/tls/db.c
+++ b/lib/proxy/tls/db.c
@@ -249,7 +249,7 @@ static int tls_db_count_sess(pool *p, void *dbh) {
   int count = 0, res;
   const char *stmt, *errstr = NULL;
   array_header *results;
-  
+
   stmt = "SELECT COUNT(*) FROM proxy_tls_sessions;";
   res = proxy_db_prepare_stmt(p, dbh, stmt);
   if (res < 0) {
@@ -272,7 +272,7 @@ static int tls_db_count_sess(pool *p, void *dbh) {
     return -1;
   }
 
-  count = atoi(((char **) results->elts)[0]); 
+  count = atoi(((char **) results->elts)[0]);
   return count;
 }
 

--- a/lib/proxy/tls/redis.c
+++ b/lib/proxy/tls/redis.c
@@ -309,7 +309,7 @@ static int tls_redis_init(pool *p, const char *tables_path, int flags) {
       pr_trace_msg(trace_channel, 3,
         "error truncating Redis keys for server '%s': %s", s->ServerName,
         strerror(errno));
-    } 
+    }
   }
 
   (void) pr_redis_conn_close(redis);

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -397,7 +397,7 @@ static void proxy_remove_symbols(void) {
   } else {
     pr_trace_msg(trace_channel, 9, "removed PRE_CMD APPE mod_xfer handlers");
   }
- 
+
   res = pr_stash_remove_cmd(C_RETR, &xfer_module, PRE_CMD, NULL, -1);
   if (res < 0) {
     pr_trace_msg(trace_channel, 1,
@@ -894,7 +894,7 @@ MODRET set_proxyreverseservers(cmd_rec *cmd) {
     if (strncmp(cmd->argv[1], "file:", 5) == 0) {
       char *param, *path;
 
-      param = cmd->argv[1]; 
+      param = cmd->argv[1];
       path = param + 5;
 
       /* If the path contains the %U or %g variables, then defer loading of
@@ -2576,7 +2576,7 @@ static int proxy_data_prepare_backend_conn(struct proxy_session *proxy_sess,
     /* We can close our listening socket now. */
     proxy_inet_close(session.pool, proxy_sess->backend_data_conn);
     pr_inet_close(session.pool, proxy_sess->backend_data_conn);
-    proxy_sess->backend_data_conn = backend_conn; 
+    proxy_sess->backend_data_conn = backend_conn;
 
     if (proxy_netio_postopen(backend_conn->instrm) < 0) {
       xerrno = errno;
@@ -2644,7 +2644,7 @@ static int proxy_data_prepare_frontend_conn(struct proxy_session *proxy_sess,
       pr_response_add_err(R_425, _("%s: %s"), (char *) cmd->argv[0],
         strerror(xerrno));
       pr_response_flush(&resp_err_list);
-    
+
       errno = xerrno;
       return -1;
     }
@@ -2683,7 +2683,7 @@ static int proxy_data_prepare_frontend_conn(struct proxy_session *proxy_sess,
 
     /* We can close our listening socket now. */
     pr_inet_close(session.pool, proxy_sess->frontend_data_conn);
-    proxy_sess->frontend_data_conn = session.d = frontend_conn; 
+    proxy_sess->frontend_data_conn = session.d = frontend_conn;
 
     pr_inet_set_nonblock(session.pool, frontend_conn);
 
@@ -2700,7 +2700,7 @@ static int proxy_data_prepare_frontend_conn(struct proxy_session *proxy_sess,
     const pr_netaddr_t *bind_addr;
 
     /* Connect to the frontend server now. */
-  
+
     if (pr_netaddr_get_family(session.c->local_addr) == pr_netaddr_get_family(session.c->remote_addr)) {
       bind_addr = session.c->local_addr;
 
@@ -3088,7 +3088,7 @@ MODRET proxy_data(struct proxy_session *proxy_sess, cmd_rec *cmd) {
         "handling data connection during data transfer");
 
       pr_timer_reset(PR_TIMER_IDLE, ANY_MODULE);
- 
+
       pbuf = proxy_ftp_data_recv(cmd->tmp_pool, src_data_conn, frontend_data);
       if (pbuf == NULL) {
         xerrno = errno;
@@ -3640,7 +3640,7 @@ MODRET proxy_eprt(cmd_rec *cmd, struct proxy_session *proxy_sess) {
     }
 
     case PR_CMD_PORT_ID:
-    case PR_CMD_EPRT_ID: 
+    case PR_CMD_EPRT_ID:
     default: {
       pr_response_t *resp;
       unsigned int resp_nlines = 0;
@@ -4399,7 +4399,7 @@ MODRET proxy_pass(cmd_rec *cmd, struct proxy_session *proxy_sess,
     if (xerrno == ECONNRESET ||
         xerrno == ECONNABORTED ||
         xerrno == EPIPE) {
-  
+
       /* This indicates that the backend server closed the control
        * connection on us.  Given that, the only thing we can do is to close
        * the frontend connection in turn.
@@ -4928,7 +4928,7 @@ MODRET proxy_any(cmd_rec *cmd) {
       } else {
         if (proxy_sess_state & PROXY_SESS_STATE_CONNECTED) {
           mr = proxy_feat(cmd, proxy_sess);
-          return mr;      
+          return mr;
         }
       }
       break;

--- a/t/api/conn.c
+++ b/t/api/conn.c
@@ -103,11 +103,11 @@ START_TEST (conn_get_addr_test) {
   const char *ipstr, *url;
   const pr_netaddr_t *pconn_addr;
   array_header *other_addrs = NULL;
- 
+
   pconn_addr = proxy_conn_get_addr(NULL, NULL);
   ck_assert_msg(pconn_addr == NULL, "Failed to handle null argument");
   ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
- 
+
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
   ck_assert_msg(pconn != NULL,
@@ -178,7 +178,7 @@ START_TEST (conn_get_hostport_test) {
   ck_assert_msg(hostport == NULL, "Failed to handle null argument");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
- 
+
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
   ck_assert_msg(pconn != NULL,
@@ -213,7 +213,7 @@ START_TEST (conn_get_uri_test) {
   pconn_url = proxy_conn_get_uri(NULL);
   ck_assert_msg(pconn_url == NULL, "Failed to handle null argument");
   ck_assert_msg(errno == EINVAL, "Failed to set errno to EINVAL");
- 
+
   url = "ftp://127.0.0.1:21";
   pconn = proxy_conn_create(p, url, 0);
   ck_assert_msg(pconn != NULL,

--- a/t/api/ftp/conn.c
+++ b/t/api/ftp/conn.c
@@ -96,7 +96,7 @@ static void tear_down(void) {
     main_server = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (accept_test) {

--- a/t/api/ftp/ctrl.c
+++ b/t/api/ftp/ctrl.c
@@ -63,7 +63,7 @@ static void tear_down(void) {
     p = permanent_pool = session.pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (handle_async_test) {

--- a/t/api/ftp/data.c
+++ b/t/api/ftp/data.c
@@ -56,7 +56,7 @@ static void tear_down(void) {
     p = permanent_pool = session.pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (recv_test) {

--- a/t/api/ftp/dirlist.c
+++ b/t/api/ftp/dirlist.c
@@ -50,7 +50,7 @@ static void tear_down(void) {
     p = permanent_pool = session.pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (init_test) {
@@ -260,7 +260,7 @@ START_TEST (to_text_test) {
   ck_assert_msg(res < 0, "Failed to handle null pool");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got %s (%d)", EINVAL,
     strerror(errno), errno);
-  
+
   mark_point();
   res = proxy_ftp_dirlist_to_text(p, NULL, 0, 0, NULL, NULL, NULL);
   ck_assert_msg(res < 0, "Failed to handle null buf");

--- a/t/api/ftp/facts.c
+++ b/t/api/ftp/facts.c
@@ -46,7 +46,7 @@ static void tear_down(void) {
   if (p != NULL) {
     destroy_pool(p);
     p = permanent_pool = session.pool = NULL;
-  } 
+  }
 }
 
 START_TEST (get_facts_test) {

--- a/t/api/ftp/msg.c
+++ b/t/api/ftp/msg.c
@@ -58,7 +58,7 @@ static void tear_down(void) {
     p = permanent_pool = session.pool = proxy_pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (fmt_addr_test) {
@@ -284,7 +284,7 @@ END_TEST
 
 START_TEST (parse_ext_addr_test) {
   const pr_netaddr_t *addr, *res;
-  const char *msg; 
+  const char *msg;
 
   res = proxy_ftp_msg_parse_ext_addr(NULL, NULL, NULL, 0, NULL);
   ck_assert_msg(res == NULL, "Failed to handle null pool");

--- a/t/api/ftp/sess.c
+++ b/t/api/ftp/sess.c
@@ -52,7 +52,7 @@ static void tear_down(void) {
     p = permanent_pool = session.pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (get_feat_test) {
@@ -68,7 +68,7 @@ START_TEST (get_feat_test) {
   ck_assert_msg(res < 0, "Failed to handle null proxy session");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
- 
+
   proxy_sess = proxy_session_alloc(p);
 
   mark_point();
@@ -76,7 +76,7 @@ START_TEST (get_feat_test) {
   ck_assert_msg(res < 0, "Failed to handle null proxy session");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);
- 
+
   proxy_session_free(p, proxy_sess);
 }
 END_TEST

--- a/t/api/ftp/xfer.c
+++ b/t/api/ftp/xfer.c
@@ -86,7 +86,7 @@ static void tear_down(void) {
     server_list = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (prepare_active_test) {
@@ -213,7 +213,7 @@ START_TEST (prepare_passive_test) {
     FALSE);
   ck_assert_msg(proxy_sess->backend_ctrl_conn != NULL,
     "Failed to open backend control conn: %s", strerror(errno));
-  
+
   session.c = pr_inet_create_conn(p, -1, NULL, INPORT_ANY, FALSE);
   ck_assert_msg(session.c != NULL,
     "Failed to open session control conn: %s", strerror(errno));

--- a/t/api/random.c
+++ b/t/api/random.c
@@ -44,7 +44,7 @@ static void tear_down(void) {
     p = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (random_next_range_10_test) {

--- a/t/api/reverse.c
+++ b/t/api/reverse.c
@@ -137,7 +137,7 @@ static void tear_down(void) {
     server_list = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (reverse_free_test) {

--- a/t/api/session.c
+++ b/t/api/session.c
@@ -82,7 +82,7 @@ static void tear_down(void) {
     server_list = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (session_free_test) {

--- a/t/api/str.c
+++ b/t/api/str.c
@@ -38,7 +38,7 @@ static void tear_down(void) {
   if (p != NULL) {
     destroy_pool(p);
     p = permanent_pool = NULL;
-  } 
+  }
 }
 
 START_TEST (strnstr_test) {

--- a/t/api/tests.c
+++ b/t/api/tests.c
@@ -54,7 +54,7 @@ static struct testsuite_info suites[] = {
   { NULL, NULL }
 };
 
-static Suite *tests_get_suite(const char *suite) { 
+static Suite *tests_get_suite(const char *suite) {
   register unsigned int i;
 
   for (i = 0; suites[i].name != NULL; i++) {

--- a/t/api/uri.c
+++ b/t/api/uri.c
@@ -50,7 +50,7 @@ static void tear_down(void) {
     p = permanent_pool = NULL;
     session.c = NULL;
     session.notes = NULL;
-  } 
+  }
 }
 
 START_TEST (uri_parse_args_test) {

--- a/t/lib/ProFTPD/Tests/Modules/mod_proxy.pm
+++ b/t/lib/ProFTPD/Tests/Modules/mod_proxy.pm
@@ -8122,7 +8122,7 @@ EOC
         die("Login succeeded unexpectedly");
       }
 
-      my $resp_code = $client->response_code(); 
+      my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
 
       my $expected = 530;
@@ -8289,7 +8289,7 @@ EOC
         die("Login succeeded unexpectedly");
       }
 
-      my $resp_code = $client->response_code(); 
+      my $resp_code = $client->response_code();
       my $resp_msg = $client->response_msg();
 
       my $expected = 530;
@@ -17885,7 +17885,7 @@ EOC
 
       $expected = 'PORT: Operation not permitted';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'")); 
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
     };
@@ -18014,7 +18014,7 @@ EOC
 
       $expected = '.: No such file or directory';
       $self->assert($expected eq $resp_msg,
-        test_msg("Expected response message '$expected', got '$resp_msg'")); 
+        test_msg("Expected response message '$expected', got '$resp_msg'"));
 
       $client->quit();
     };
@@ -19893,7 +19893,7 @@ EOC
         $expected = $test_file;
         $self->assert($expected eq $filename,
           test_msg("Expected file name '$expected', got '$filename'"));
-  
+
         $expected = 'a';
         $self->assert($expected eq $xfer_type,
           test_msg("Expected transfer type '$expected', got '$xfer_type'"));
@@ -20150,7 +20150,7 @@ EOC
         $expected = $test_file;
         $self->assert($expected eq $filename,
           test_msg("Expected file name '$expected', got '$filename'"));
-  
+
         $expected = 'a';
         $self->assert($expected eq $xfer_type,
           test_msg("Expected transfer type '$expected', got '$xfer_type'"));
@@ -20391,7 +20391,7 @@ EOC
         $expected = $test_file;
         $self->assert($expected eq $filename,
           test_msg("Expected file name '$expected', got '$filename'"));
-  
+
         $expected = 'b';
         $self->assert($expected eq $xfer_type,
           test_msg("Expected transfer type '$expected', got '$xfer_type'"));
@@ -20615,7 +20615,7 @@ EOC
         $expected = $test_file;
         $self->assert($expected eq $filename,
           test_msg("Expected file name '$expected', got '$filename'"));
-  
+
         $expected = 'a';
         $self->assert($expected eq $xfer_type,
           test_msg("Expected transfer type '$expected', got '$xfer_type'"));
@@ -20839,7 +20839,7 @@ EOC
         $expected = $test_file;
         $self->assert($expected eq $filename,
           test_msg("Expected file name '$expected', got '$filename'"));
-  
+
         $expected = 'b';
         $self->assert($expected eq $xfer_type,
           test_msg("Expected transfer type '$expected', got '$xfer_type'"));
@@ -28106,11 +28106,11 @@ EOC
       $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 
@@ -28278,11 +28278,11 @@ EOC
       my $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 
@@ -28452,11 +28452,11 @@ EOC
       my $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 
@@ -29998,11 +29998,11 @@ EOC
       $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 
@@ -30170,11 +30170,11 @@ EOC
       my $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 
@@ -30342,11 +30342,11 @@ EOC
       my $expected = 530;
       $self->assert($expected == $resp_code,
         test_msg("Expected response code $expected, got $resp_code"));
-      
+
       $expected = 'Login incorrect.';
       $self->assert($expected eq $resp_msg,
         test_msg("Expected response message '$expected', got '$resp_msg'"));
-      
+
       $client->quit();
     };
 

--- a/t/lib/ProFTPD/Tests/Modules/mod_proxy/tls.pm
+++ b/t/lib/ProFTPD/Tests/Modules/mod_proxy/tls.pm
@@ -657,7 +657,7 @@ EOC
     eval {
       # Give the server a chance to start up
       sleep(2);
- 
+
       my $client_opts = {
         Encryption => 'E',
         Port => $port,
@@ -827,7 +827,7 @@ EOC
     eval {
       # Give the server a chance to start up
       sleep(2);
- 
+
       my $client_opts = {
         Encryption => 'E',
         Port => $port,
@@ -1017,7 +1017,7 @@ EOC
         SSL_key_file => $client_cert_file,
         SSL_ca_file => $ca_file,
       };
- 
+
       my $client_opts = {
         Encryption => 'E',
         Port => $port,


### PR DESCRIPTION
Discovered using:
```
find . -type f -name "*.[ch]" -print | xargs egrep -n '.* +$'
find . -type f -name "*.pm" -print | xargs egrep -n '.* +$'
```
No functional change.