### PR TITLE
Fix compilation with old OpenSSL versions

### DIFF
--- a/lib/proxy/ssh.c
+++ b/lib/proxy/ssh.c
@@ -44,6 +44,7 @@
 #include "proxy/ssh/utf8.h"
 
 #if defined(PR_USE_OPENSSL)
+#include <openssl/conf.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 

--- a/lib/proxy/ssh/crypto.c
+++ b/lib/proxy/ssh/crypto.c
@@ -36,6 +36,12 @@
 #endif /* !OPENSSL_NO_DES */
 #include <openssl/err.h>
 
+#if OPENSSL_VERSION_NUMBER > 0x000907000L && \
+    OPENSSL_VERSION_NUMBER < 0x10100000L
+#include <openssl/engine.h>
+static const char *crypto_engine = NULL;
+#endif
+
 struct proxy_ssh_cipher {
   const char *name;
   const char *openssl_name;


### PR DESCRIPTION
I got a request to build mod_proxy in Fedora EPEL (https://bugzilla.redhat.com/show_bug.cgi?id=2272051) so I tried building it with a bunch ol older Fedora versions locally and came across some issues with old OpenSSL versions, which are addressed in this PR.

