### PR TITLE
Issue #280: Disable the switching of process identity only after succ…

### DIFF
--- a/lib/proxy/session.c
+++ b/lib/proxy/session.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy session routines
- * Copyright (c) 2012-2022 TJ Saunders
+ * Copyright (c) 2012-2024 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -298,8 +298,6 @@ int proxy_session_setup_env(pool *p, const char *user, int flags) {
     pr_log_pri(PR_LOG_WARNING, "unable to set process groups: %s",
       strerror(xerrno));
   }
-
-  session.disable_id_switching = TRUE;
 
   session.proc_prefix = pstrdup(session.pool, session.c->remote_name);
   session.sf_flags = 0;

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -485,6 +485,8 @@ static void proxy_restrict_session(void) {
    */
   PRIVS_REVOKE
 
+  session.disable_id_switching = TRUE;
+
   if (proxy_chroot != NULL) {
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "proxy session running as UID %lu, GID %lu, restricted to '%s'",


### PR DESCRIPTION
…essfully authenticating to the backend server.

When proxy auth is used, the flag to disable process identity switching was set after proxy auth, but before backend auth.  And that, in turn, meant that after successful backend auth, the switching to root privs for making the automatic `chroot(2)` call of the proxy session process would silently fail, leading to unexpected `chroot(2)` failure due to EPERM.