### PR TITLE
Issue #285: Implement an `IgnoreForeignAddress` ProxyOption, such tha…

### DIFF
--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -816,6 +816,9 @@ MODRET set_proxyoptions(cmd_rec *cmd) {
     } else if (strcmp(cmd->argv[i], "AllowForeignAddress") == 0) {
       opts |= PROXY_OPT_ALLOW_FOREIGN_ADDRESS;
 
+    } else if (strcmp(cmd->argv[i], "IgnoreForeignAddress") == 0) {
+      opts |= PROXY_OPT_IGNORE_FOREIGN_ADDRESS;
+
     } else {
       CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, ": unknown ProxyOption '",
         (char *) cmd->argv[i], "'", NULL));

--- a/mod_proxy.h.in
+++ b/mod_proxy.h.in
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy
- * Copyright (c) 2012-2024 TJ Saunders
+ * Copyright (c) 2012-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -104,6 +104,7 @@
 #define PROXY_OPT_USE_PROXY_PROTOCOL_V2		0x0020
 #define PROXY_OPT_USE_PROXY_PROTOCOL_V2_TLVS	0x0040
 #define PROXY_OPT_ALLOW_FOREIGN_ADDRESS		0x0080
+#define PROXY_OPT_IGNORE_FOREIGN_ADDRESS	0x0100
 
 /* mod_proxy datastores */
 #define PROXY_DATASTORE_SQLITE			1

--- a/mod_proxy.html
+++ b/mod_proxy.html
@@ -504,6 +504,37 @@ The currently implemented options are:
   # address for data transfers than the IP address to which mod_proxy connected.
   ProxyOptions AllowForeignAddress
     </pre>
+
+    <p>
+    Note that the <code>IgnoreForeignAddress</code> option takes precedence
+    over this option.
+  </li>
+
+  <p>
+  <li><code>IgnoreForeignAddress</code><br>
+    <p>
+    Use this option to tell the <code>mod_proxy</code> module to <i>always</i>
+    use the same IP address for passive data transfers to the backend server as
+    used for the control connection, ignoring any different IP address that
+    the backend server may provide in its <code>PASV</code> response.
+
+    <p>
+    This option may be needed in cases where you see backend data transfers fail with errors logged such as:
+    <pre>
+      unable to connect to 172.16.1.2#8200: Network unreachable
+      unable to connect to 172.16.2.2#8200: Connection refused
+    </pre>
+    Example:
+    <pre>
+  # When the backend server tells us to use a different IP address for data
+  # transfers than the IP address to which mod_proxy connected, ignore that
+  # different IP address and use the original initial IP address.
+  ProxyOptions IgnoreForeignAddress
+    </pre>
+
+    <p>
+    Note that this option takes precedence over the
+    <code>AllowForeignAddress</code> option.
   </li>
 
   <p>
@@ -2561,7 +2592,7 @@ development library/header files <b>must</b> be installed for building
 <hr>
 
 <font size=2><b><i>
-&copy; Copyright 2015-2024 TJ Saunders<br>
+&copy; Copyright 2015-2025 TJ Saunders<br>
  All Rights Reserved<br>
 </i></b></font>
 


### PR DESCRIPTION
…t backend passive data transfers always use the same IP address as used for the control connection, regardless of the address provided in the backend server's PASV response.