### PR TITLE
Issue #285: Make sure that the address family for the remote/backend …

### DIFF
--- a/lib/proxy/ftp/xfer.c
+++ b/lib/proxy/ftp/xfer.c
@@ -570,7 +570,7 @@ const pr_netaddr_t *proxy_ftp_xfer_prepare_passive(int policy_id, cmd_rec *cmd,
 
       remote_addr = pr_netaddr_dup(proxy_sess->dataxfer_pool,
         proxy_sess->backend_ctrl_conn->remote_addr);
-      pr_netaddr_set_port2(remote_addr, remote_port);
+      pr_netaddr_set_port2((pr_netaddr_t *) remote_addr, remote_port);
 
     } else {
       if (!(proxy_opts & PROXY_OPT_ALLOW_FOREIGN_ADDRESS)) {


### PR DESCRIPTION
…data connection address matches that of the control address.

Mismatches in address families will cause `connect(2)`, for backend passive data transfers, to yield `EINVAL` due to the socket fd using one address family, and the socket _address_ using a different address family.  Subtle.