### PR TITLE
Issue #249: By requiring linking with OpenSSL, we now no longer need …

### DIFF
--- a/include/proxy/ssh/agent.h
+++ b/include/proxy/ssh/agent.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH agent API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
-
 struct agent_key {
   unsigned char *key_data;
   uint32_t key_datalen;
@@ -42,7 +40,5 @@ const unsigned char *proxy_ssh_agent_sign_data(pool *, const char *,
 
 #define PROXY_SSH_AGENT_SIGN_FL_USE_RSA_SHA256	0x001
 #define PROXY_SSH_AGENT_SIGN_FL_USE_RSA_SHA512	0x002
-
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_AGENT_H */

--- a/include/proxy/ssh/auth.h
+++ b/include/proxy/ssh/auth.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH auth API
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,6 @@
 #include "proxy/session.h"
 #include "proxy/ssh/packet.h"
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_auth_init(pool *p);
 int proxy_ssh_auth_sess_init(pool *p, const struct proxy_session *proxy_sess);
 
@@ -41,6 +40,5 @@ int proxy_ssh_auth_handle(struct proxy_ssh_packet *pkt,
 
 int proxy_ssh_auth_set_frontend_success_handle(pool *p, int (*cb)(pool *p,
   const char *user));
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_AUTH_H */

--- a/include/proxy/ssh/bcrypt.h
+++ b/include/proxy/ssh/bcrypt.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH bcrypt PBKDF2
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,12 +27,10 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 #define PROXY_SSH_BCRYPT_DIGEST_LEN	32
 
 int proxy_ssh_bcrypt_pbkdf2(pool *p, const char *passphrase,
   size_t passphrase_len, unsigned char *salt, uint32_t salt_len,
   uint32_t rounds, unsigned char *key, uint32_t key_len);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_BCRYPT_H */

--- a/include/proxy/ssh/cipher.h
+++ b/include/proxy/ssh/cipher.h
@@ -27,7 +27,6 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/evp.h>
 
 int proxy_ssh_cipher_init(void);
@@ -69,6 +68,5 @@ int proxy_ssh_cipher_set_write_key(pool *p, const EVP_MD *md,
   int role);
 int proxy_ssh_cipher_write_data(struct proxy_ssh_packet *pkt,
   unsigned char *buf, size_t *bufsz);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_CIPHER_H */

--- a/include/proxy/ssh/compress.h
+++ b/include/proxy/ssh/compress.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH compression API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,8 +28,6 @@
 #include "mod_proxy.h"
 #include "proxy/ssh/packet.h"
 
-#if defined(PR_USE_OPENSSL)
-
 #define PROXY_SSH_COMPRESS_FL_NEW_KEY		1
 #define PROXY_SSH_COMPRESS_FL_AUTHENTICATED	2
 
@@ -42,6 +40,5 @@ int proxy_ssh_compress_init_write(int);
 const char *proxy_ssh_compress_get_write_algo(void);
 int proxy_ssh_compress_set_write_algo(pool *p, const char *algo);
 int proxy_ssh_compress_write_data(struct proxy_ssh_packet *);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_COMPRESS_H */

--- a/include/proxy/ssh/crypto.h
+++ b/include/proxy/ssh/crypto.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH crypto API
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/evp.h>
 
 void proxy_ssh_crypto_free(int flags);
@@ -39,6 +38,5 @@ const char *proxy_ssh_crypto_get_kexinit_digest_list(pool *p);
 
 const char *proxy_ssh_crypto_get_errors(void);
 size_t proxy_ssh_crypto_get_size(size_t, size_t);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_CRYPTO_H */

--- a/include/proxy/ssh/db.h
+++ b/include/proxy/ssh/db.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH Database API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,9 +28,7 @@
 #include "mod_proxy.h"
 #include "proxy/ssh.h"
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_db_as_datastore(struct proxy_ssh_datastore *ds, void *ds_data,
   size_t ds_datasz);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_DB_H */

--- a/include/proxy/ssh/disconnect.h
+++ b/include/proxy/ssh/disconnect.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH disconnect API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
-
 void proxy_ssh_disconnect_conn(conn_t *, uint32_t, const char *, const char *,
   int, const char *);
 void proxy_ssh_disconnect_send(pool *, conn_t *, uint32_t, const char *,
@@ -43,19 +41,18 @@ const char *proxy_ssh_disconnect_get_text(uint32_t);
  * (e.g. SunStudio) like __func__.
  */
 
-# if defined(__FUNCTION__)
+#if defined(__FUNCTION__)
 #define PROXY_SSH_DISCONNECT_CONN(c, n, m) \
   proxy_ssh_disconnect_conn((c), (n), (m), __FILE__, __LINE__, __FUNCTION__)
 
-# elif defined(__func__)
+#elif defined(__func__)
 #define PROXY_SSH_DISCONNECT_CONN(c, n, m) \
   proxy_ssh_disconnect_conn((c), (n), (m), __FILE__, __LINE__, __func__)
 
-# else
+#else
 #define PROXY_SSH_DISCONNECT_CONN(c, n, m) \
   proxy_ssh_disconnect_conn((c), (n), (m), __FILE__, __LINE__, "")
 
-# endif
-#endif /* PR_USE_OPENSSL */
+#endif
 
 #endif /* MOD_PROXY_SSH_DISCONNECT_H */

--- a/include/proxy/ssh/interop.h
+++ b/include/proxy/ssh/interop.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH interop API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 
 #include "mod_proxy.h"
 #include "proxy/session.h"
-
-#if defined(PR_USE_OPENSSL)
 
 /* For servers which do not support IGNORE packets */
 #define PROXY_SSH_FEAT_IGNORE_MSG			0x0001
@@ -98,6 +96,5 @@ int proxy_ssh_interop_supports_feature(int);
 
 int proxy_ssh_interop_init(void);
 int proxy_ssh_interop_free(void);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_INTEROP_H */

--- a/include/proxy/ssh/kex.h
+++ b/include/proxy/ssh/kex.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH kex API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,8 +29,6 @@
 #include "proxy/session.h"
 #include "proxy/ssh.h"
 
-#if defined(PR_USE_OPENSSL)
-
 int proxy_ssh_kex_handle(struct proxy_ssh_packet *pkt,
   const struct proxy_session *proxy_sess);
 int proxy_ssh_kex_init(pool *p, const char *client_version,
@@ -46,6 +44,5 @@ int proxy_ssh_kex_send_first_kexinit(pool *p,
 
 #define PROXY_SSH_KEX_DH_GROUP_MIN	1024
 #define PROXY_SSH_KEX_DH_GROUP_MAX	8192
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_KEX_H */

--- a/include/proxy/ssh/keys.h
+++ b/include/proxy/ssh/keys.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH keys API
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,7 +27,6 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/ec.h>
 
 enum proxy_ssh_key_type_e {
@@ -77,6 +76,5 @@ int proxy_ssh_keys_verify_signed_data(pool *p, const char *pubkey_algo,
   unsigned char *pubkey_data, uint32_t pubkey_datalen,
   unsigned char *signature, uint32_t signaturelen,
   unsigned char *sig_data, size_t sig_datalen);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_KEYS_H */

--- a/include/proxy/ssh/mac.h
+++ b/include/proxy/ssh/mac.h
@@ -28,7 +28,6 @@
 #include "mod_proxy.h"
 #include "proxy/ssh/packet.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/evp.h>
 
 int proxy_ssh_mac_init(void);
@@ -55,6 +54,5 @@ int proxy_ssh_mac_set_write_key(pool *p, const EVP_MD *md,
   const unsigned char *k, uint32_t klen, const char *h, uint32_t hlen,
   int role);
 int proxy_ssh_mac_write_data(struct proxy_ssh_packet *pkt);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_MAC_H */

--- a/include/proxy/ssh/misc.h
+++ b/include/proxy/ssh/misc.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH miscellany API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,9 +27,7 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_misc_namelist_contains(pool *, const char *, const char *);
 const char *proxy_ssh_misc_namelist_shared(pool *, const char *, const char *);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_MISC_H */

--- a/include/proxy/ssh/msg.h
+++ b/include/proxy/ssh/msg.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH message API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,7 @@
 #define MOD_PROXY_SSH_MSG_H
 
 #include "mod_proxy.h"
-
-#if defined(PR_USE_OPENSSL)
+#include <openssl/bn.h>
 
 #if defined(PR_USE_OPENSSL_ECC)
 # include <openssl/ec.h>
@@ -71,6 +70,5 @@ uint32_t proxy_ssh_msg_write_mpint(unsigned char **buf, uint32_t *buflen,
   const BIGNUM *msg);
 uint32_t proxy_ssh_msg_write_string(unsigned char **buf, uint32_t *buflen,
   const char *msg);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_MSG_H */

--- a/include/proxy/ssh/packet.h
+++ b/include/proxy/ssh/packet.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH packet API
- * Copyright (c) 2021-2023 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 
 #include "mod_proxy.h"
 #include "proxy/session.h"
-
-#if defined(PR_USE_OPENSSL)
 
 /* From RFC 4253, Section 6 */
 /* NOTE: This struct MUST be kept in sync with the struct used in mod_sftp;
@@ -152,7 +150,5 @@ int proxy_ssh_packet_set_server_alive(unsigned int, unsigned int);
 
 int proxy_ssh_packet_set_frontend_packet_handle(pool *p, int (*cb)(void *pkt));
 void proxy_ssh_packet_set_frontend_packet_write(int (*cb)(int fd, void *pkt));
-
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_PACKET_H */

--- a/include/proxy/ssh/service.h
+++ b/include/proxy/ssh/service.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH service API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,9 +29,7 @@
 #include "proxy/session.h"
 #include "proxy/ssh/packet.h"
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_service_handle(struct proxy_ssh_packet *,
   const struct proxy_session *);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_SERVICE_H */

--- a/include/proxy/ssh/session.h
+++ b/include/proxy/ssh/session.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH session API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,13 +27,11 @@
 
 #include "mod_proxy.h"
 
-#if defined(PR_USE_OPENSSL)
 uint32_t proxy_ssh_session_get_id(const unsigned char **);
 
 /* Note that the provided pool must have the same lifetime as that of the
  * entire SSH session, e.g. proxy_pool or similar.
  */
 int proxy_ssh_session_set_id(pool *p, const unsigned char *, uint32_t);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_SESSION_H */

--- a/include/proxy/ssh/utf8.h
+++ b/include/proxy/ssh/utf8.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH UTF8 API
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,8 +25,6 @@
 #ifndef MOD_PROXY_SSH_UTF8_H
 #define MOD_PROXY_SSH_UTF8_H
 
-#if defined(PR_USE_OPENSSL)
-
 char *proxy_ssh_utf8_decode_text(pool *p, const char *text);
 char *proxy_ssh_utf8_encode_text(pool *p, const char *text);
 
@@ -37,6 +35,5 @@ int proxy_ssh_utf8_set_charset(const char *charset);
 
 int proxy_ssh_utf8_init(void);
 int proxy_ssh_utf8_free(void);
-#endif /* PR_USE_OPENSSL */
 
 #endif /* MOD_PROXY_SSH_UTF8_H */

--- a/include/proxy/tls.h
+++ b/include/proxy/tls.h
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy TLS API
- * Copyright (c) 2015-2024 TJ Saunders
+ * Copyright (c) 2015-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,27 +28,25 @@
 #include "mod_proxy.h"
 #include "proxy/session.h"
 
-#ifdef PR_USE_OPENSSL
-# include <openssl/bio.h>
-# include <openssl/err.h>
-# include <openssl/conf.h>
-# include <openssl/crypto.h>
-# include <openssl/evp.h>
-# include <openssl/ssl.h>
-# include <openssl/ssl3.h>
-# include <openssl/x509v3.h>
-# include <openssl/rand.h>
-# if OPENSSL_VERSION_NUMBER > 0x000907000L
-#  if defined(PR_USE_OPENSSL_ENGINE)
-#   include <openssl/engine.h>
-#  endif /* PR_USE_OPENSSL_ENGINE */
-#  include <openssl/ocsp.h>
-# endif
-# ifdef PR_USE_OPENSSL_ECC
-#  include <openssl/ec.h>
-#  include <openssl/ecdh.h>
-# endif /* PR_USE_OPENSSL_ECC */
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/conf.h>
+#include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/ssl.h>
+#include <openssl/ssl3.h>
+#include <openssl/x509v3.h>
+#include <openssl/rand.h>
+#if OPENSSL_VERSION_NUMBER > 0x000907000L
+# if defined(PR_USE_OPENSSL_ENGINE)
+#  include <openssl/engine.h>
+# endif /* PR_USE_OPENSSL_ENGINE */
+# include <openssl/ocsp.h>
 #endif
+#ifdef PR_USE_OPENSSL_ECC
+# include <openssl/ec.h>
+# include <openssl/ecdh.h>
+#endif /* PR_USE_OPENSSL_ECC */
 
 /* ProxyTLSEngine values */
 #define PROXY_TLS_ENGINE_ON		1
@@ -112,12 +110,10 @@ int proxy_tls_match_client_tls(void);
 
 /* Defines the datastore interface. */
 struct proxy_tls_datastore {
-#ifdef PR_USE_OPENSSL
   int (*add_sess)(pool *p, void *dsh, const char *key, SSL_SESSION *sess);
   int (*remove_sess)(pool *p, void *dsh, const char *key);
   SSL_SESSION *(*get_sess)(pool *p, void *dsh, const char *key);
   int (*count_sess)(pool *p, void *dsh);
-#endif /* PR_USE_OPENSSL */
   int (*init)(pool *p, const char *path, int flags);
   void *(*open)(pool *p, const char *path, unsigned long opts);
   int (*close)(pool *p, void *dsh);

--- a/lib/proxy/ssh.c
+++ b/lib/proxy/ssh.c
@@ -43,7 +43,6 @@
 #include "proxy/ssh/mac.h"
 #include "proxy/ssh/utf8.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/conf.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -665,10 +664,8 @@ static void ssh_ssh2_read_poll_ev(const void *event_data, void *user_data) {
   proxy_ssh_packet_set_poll_timeout(poll_timeout_secs, poll_timeout_ms);
   destroy_pool(tmp_pool);
 }
-#endif /* PR_USE_OPENSSL */
 
 int proxy_ssh_init(pool *p, const char *tables_path, int flags) {
-#if defined(PR_USE_OPENSSL)
   int res;
   config_rec *c;
 
@@ -733,8 +730,6 @@ int proxy_ssh_init(pool *p, const char *tables_path, int flags) {
   }
 
   proxy_ssh_keys_get_passphrases();
-#endif /* PR_USE_OPENSSL */
-
   return 0;
 }
 
@@ -744,7 +739,6 @@ int proxy_ssh_free(pool *p) {
     return -1;
   }
 
-#if defined(PR_USE_OPENSSL)
   if (ssh_ds.dsh != NULL) {
     int res;
 
@@ -766,13 +760,10 @@ int proxy_ssh_free(pool *p) {
   proxy_ssh_utf8_free();
   proxy_ssh_crypto_free(0);
 
-#endif /* PR_USE_OPENSSL */
-
   return 0;
 }
 
 int proxy_ssh_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
-#if defined(PR_USE_OPENSSL)
   int connect_policy_id = PROXY_REVERSE_CONNECT_POLICY_ROUND_ROBIN;
   int sftp_engine, proxy_role = 0, verify_server, xerrno = 0;
   config_rec *c;
@@ -935,7 +926,7 @@ int proxy_ssh_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
   if (proxy_ssh_auth_sess_init(p, proxy_sess) < 0) {
     return -1;
   }
-#endif /* PR_USE_OPENSSL */
+
   return 0;
 }
 
@@ -945,7 +936,6 @@ int proxy_ssh_sess_free(pool *p) {
     return -1;
   }
 
-#if defined(PR_USE_OPENSSL)
   ssh_opts = 0UL;
 
   if (ssh_ds.dsh != NULL) {
@@ -967,7 +957,6 @@ int proxy_ssh_sess_free(pool *p) {
     ssh_ssh2_kex_completed_ev);
   pr_event_unregister(&proxy_module, "mod_sftp.ssh2.read-poll",
     ssh_ssh2_read_poll_ev);
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }

--- a/lib/proxy/ssh/agent.c
+++ b/lib/proxy/ssh/agent.c
@@ -26,8 +26,6 @@
 #include "proxy/ssh/agent.h"
 #include "proxy/ssh/msg.h"
 
-#if defined(PR_USE_OPENSSL)
-
 static const char *trace_channel = "proxy.ssh.agent";
 
 /* These values from https://tools.ietf.org/html/draft-miller-ssh-agent-04
@@ -399,4 +397,3 @@ const unsigned char *proxy_ssh_agent_sign_data(pool *p, const char *agent_path,
 
   return sig_data;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/auth.c
+++ b/lib/proxy/ssh/auth.c
@@ -37,8 +37,6 @@
 #include "proxy/ssh/keys.h"
 #include "proxy/ssh/utf8.h"
 
-#if defined(PR_USE_OPENSSL)
-
 /* From response.c */
 extern pr_response_t *resp_list, *resp_err_list;
 
@@ -1296,4 +1294,3 @@ int proxy_ssh_auth_set_frontend_success_handle(pool *p,
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/bcrypt.c
+++ b/lib/proxy/ssh/bcrypt.c
@@ -22,7 +22,6 @@
 #include "proxy/ssh/bcrypt.h"
 #include "proxy/ssh/crypto.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/sha.h>
 
 #define	MINIMUM(a,b) (((a) < (b)) ? (a) : (b))
@@ -219,4 +218,3 @@ int proxy_ssh_bcrypt_pbkdf2(pool *p, const char *passphrase,
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/cipher.c
+++ b/lib/proxy/ssh/cipher.c
@@ -32,7 +32,6 @@
 #include "proxy/ssh/interop.h"
 #include "proxy/ssh/poly1305.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/evp.h>
 
 struct proxy_ssh_cipher {
@@ -1635,4 +1634,3 @@ int proxy_ssh_cipher_free(void) {
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/compress.c
+++ b/lib/proxy/ssh/compress.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH compression
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,9 +29,7 @@
 #include "proxy/ssh/crypto.h"
 #include "proxy/ssh/compress.h"
 
-#if defined(PR_USE_OPENSSL)
-
-#ifdef HAVE_ZLIB_H
+#if defined(HAVE_ZLIB_H)
 #include <zlib.h>
 
 static const char *trace_channel = "proxy.ssh.compress";
@@ -573,5 +571,3 @@ int proxy_ssh_compress_write_data(struct proxy_ssh_packet *pkt) {
   return 0;
 }
 #endif /* !HAVE_ZLIB_H */
-
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/crypto.c
+++ b/lib/proxy/ssh/crypto.c
@@ -26,7 +26,6 @@
 #include "proxy/ssh/crypto.h"
 #include "proxy/ssh/umac.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/aes.h>
 #if !defined(OPENSSL_NO_BF)
 # include <openssl/blowfish.h>
@@ -1444,4 +1443,3 @@ void proxy_ssh_crypto_free(int flags) {
 #endif /* prior to OpenSSL-1.1.x */
   }
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/db.c
+++ b/lib/proxy/ssh/db.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH database implementation
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 #include "proxy/db.h"
 #include "proxy/ssh.h"
 #include "proxy/ssh/db.h"
-
-#if defined(PR_USE_OPENSSL)
 
 extern xaset_t *server_list;
 
@@ -434,4 +432,3 @@ int proxy_ssh_db_as_datastore(struct proxy_ssh_datastore *ds, void *ds_data,
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/disconnect.c
+++ b/lib/proxy/ssh/disconnect.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH disconnects
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 #include "proxy/ssh/msg.h"
 #include "proxy/ssh/packet.h"
 #include "proxy/ssh/disconnect.h"
-
-#if defined(PR_USE_OPENSSL)
 
 struct disconnect_reason {
   uint32_t code;
@@ -149,4 +147,3 @@ void proxy_ssh_disconnect_conn(conn_t *conn, uint32_t reason,
   pr_session_disconnect(&proxy_module, PR_SESS_DISCONNECT_BY_APPLICATION, NULL);
 #endif /* PR_DEVEL_COREDUMP */
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/interop.c
+++ b/lib/proxy/ssh/interop.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH interoperability
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@
 #include "proxy/ssh/ssh2.h"
 #include "proxy/ssh/disconnect.h"
 #include "proxy/ssh/interop.h"
-
-#if defined(PR_USE_OPENSSL)
 
 /* By default, each server is assumed to support all of the features in
  * which we are interested.
@@ -340,4 +338,3 @@ int proxy_ssh_interop_free(void) {
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/kex.c
+++ b/lib/proxy/ssh/kex.c
@@ -39,17 +39,16 @@
 #include "proxy/ssh/interop.h"
 #include "proxy/ssh/misc.h"
 
-#if defined(PR_USE_OPENSSL)
-# include <openssl/bn.h>
-# include <openssl/dh.h>
-# include <openssl/evp.h>
-# include <openssl/rand.h>
-# include <openssl/rsa.h>
+#include <openssl/bn.h>
+#include <openssl/dh.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/rsa.h>
 
-# if defined(PR_USE_OPENSSL_ECC)
-#  include <openssl/ec.h>
-#  include <openssl/ecdh.h>
-# endif /* PR_USE_OPENSSL_ECC */
+#if defined(PR_USE_OPENSSL_ECC)
+# include <openssl/ec.h>
+# include <openssl/ecdh.h>
+#endif /* PR_USE_OPENSSL_ECC */
 
 #if defined(PR_USE_SODIUM)
 # include <sodium.h>
@@ -5285,4 +5284,3 @@ int proxy_ssh_kex_send_first_kexinit(pool *p,
   destroy_pool(pkt->pool);
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/keys.c
+++ b/lib/proxy/ssh/keys.c
@@ -32,8 +32,6 @@
 #include "proxy/ssh/interop.h"
 #include "proxy/ssh/bcrypt.h"
 
-#if defined(PR_USE_OPENSSL)
-
 #if defined(PR_USE_SODIUM)
 # include <sodium.h>
 #endif /* PR_USE_SODIUM */
@@ -1645,35 +1643,35 @@ static const char *get_pkey_type_desc(int pkey_type) {
   const char *key_desc = NULL;
 
   switch (pkey_type) {
-#ifdef EVP_PKEY_NONE
+#if defined(EVP_PKEY_NONE)
     case EVP_PKEY_NONE:
       key_desc = "undefined";
       break;
-#endif
+#endif /* EVP_PKEY_NONE */
 
-#ifdef EVP_PKEY_RSA
+#if defined(EVP_PKEY_RSA)
     case EVP_PKEY_RSA:
       key_desc = "RSA";
       break;
-#endif
+#endif /* EVP_PKEY_RSA */
 
-#ifdef EVP_PKEY_DSA
+#if defined(EVP_PKEY_DSA)
     case EVP_PKEY_DSA:
       key_desc = "DSA";
       break;
-#endif
+#endif /* EVP_PKEY_DSA */
 
-#ifdef EVP_PKEY_DH
+#if defined(EVP_PKEY_DH)
     case EVP_PKEY_DH:
       key_desc = "DH";
       break;
-#endif
+#endif /* EVP_PKEY_DH */
 
-#ifdef EVP_PKEY_EC
+#if defined(EVP_PKEY_EC)
     case EVP_PKEY_EC:
       key_desc = "ECC";
       break;
-#endif
+#endif /* EVP_PKEY_EC */
 
     default:
       key_desc = "unknown";
@@ -1812,6 +1810,7 @@ static int validate_ecdsa_private_key(const EC_KEY *ec) {
   BN_CTX_free(bn_ctx);
   return 0;
 }
+#endif /* PR_USE_OPENSSL_ECC */
 
 enum proxy_ssh_key_type_e proxy_ssh_keys_get_key_type(const char *algo) {
   enum proxy_ssh_key_type_e key_type = PROXY_SSH_KEY_UNKNOWN;
@@ -2103,7 +2102,6 @@ int proxy_ssh_keys_validate_ecdsa_params(const EC_GROUP *group,
   BN_CTX_free(bn_ctx);
   return 0;
 }
-#endif /* PR_USE_OPENSSL_ECC */
 
 #ifdef SFTP_DEBUG_KEYS
 static void debug_rsa_key(pool *p, const char *label, RSA *rsa) {
@@ -5719,4 +5717,3 @@ void proxy_ssh_keys_free(void) {
   clear_ed25519_hostkey();
   clear_rsa_hostkey();
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/mac.c
+++ b/lib/proxy/ssh/mac.c
@@ -34,8 +34,6 @@
 #include "proxy/ssh/disconnect.h"
 #include "proxy/ssh/interop.h"
 
-#if defined(PR_USE_OPENSSL)
-
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
@@ -1110,4 +1108,3 @@ int proxy_ssh_mac_free(void) {
 #endif /* OpenSSL-1.1.0 and later */
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/misc.c
+++ b/lib/proxy/ssh/misc.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH miscellany
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,7 +25,6 @@
 #include "mod_proxy.h"
 #include "proxy/ssh/misc.h"
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_misc_namelist_contains(pool *p, const char *namelist,
     const char *name) {
   register unsigned int i;
@@ -87,4 +86,3 @@ const char *proxy_ssh_misc_namelist_shared(pool *p, const char *c2s_names,
 
   return name;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/msg.c
+++ b/lib/proxy/ssh/msg.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH message format
- * Copyright (c) 2021-2024 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -28,8 +28,6 @@
 #include "proxy/ssh/msg.h"
 #include "proxy/ssh/crypto.h"
 #include "proxy/ssh/disconnect.h"
-
-#if defined(PR_USE_OPENSSL)
 
 #if defined(PR_USE_OPENSSL_ECC)
 /* Max GFp field length = 528 bits.  SEC1 uncompressed encoding uses 2
@@ -583,5 +581,3 @@ uint32_t proxy_ssh_msg_write_ecpoint(unsigned char **buf, uint32_t *buflen,
   return len;
 }
 #endif /* PR_USE_OPENSSL_ECC */
-
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/packet.c
+++ b/lib/proxy/ssh/packet.c
@@ -43,8 +43,6 @@
 # define MIN(x, y) (((x) < (y)) ? (x) : (y))
 #endif
 
-#if defined(PR_USE_OPENSSL)
-
 extern pr_response_t *resp_list, *resp_err_list;
 
 static int (*frontend_packet_write)(int, void *) = NULL;
@@ -2364,4 +2362,3 @@ int proxy_ssh_packet_set_version(const char *version) {
   version_id = pstrcat(proxy_pool, version, "\r\n", NULL);
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/redis.c
+++ b/lib/proxy/ssh/redis.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH Redis implementation
- * Copyright (c) 2022 TJ Saunders
+ * Copyright (c) 2022-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -29,7 +29,6 @@
 #include "proxy/ssh/crypto.h"
 #include "proxy/ssh/redis.h"
 
-#if defined(PR_USE_OPENSSL)
 #include <openssl/evp.h>
 
 extern xaset_t *server_list;
@@ -279,4 +278,3 @@ int proxy_ssh_redis_as_datastore(struct proxy_ssh_datastore *ds, void *ds_data,
 
   return 0;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/service.c
+++ b/lib/proxy/ssh/service.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH service
- * Copyright (c) 2021-2022 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -26,8 +26,6 @@
 #include "proxy/ssh/ssh2.h"
 #include "proxy/ssh/packet.h"
 #include "proxy/ssh/service.h"
-
-#if defined(PR_USE_OPENSSL)
 
 static const char *trace_channel = "proxy.ssh.service";
 
@@ -114,4 +112,3 @@ int proxy_ssh_service_handle(struct proxy_ssh_packet *pkt,
   errno = xerrno;
   return res;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/session.c
+++ b/lib/proxy/ssh/session.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH session
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,8 +24,6 @@
 
 #include "mod_proxy.h"
 #include "proxy/ssh/session.h"
-
-#if defined(PR_USE_OPENSSL)
 #include <openssl/rand.h>
 
 static unsigned char *session_id = NULL;
@@ -65,4 +63,3 @@ int proxy_ssh_session_set_id(pool *p, const unsigned char *hash,
   errno = EEXIST;
   return -1;
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/ssh/umac.c
+++ b/lib/proxy/ssh/umac.c
@@ -72,13 +72,11 @@
 
 #include "mod_proxy.h"
 #include "proxy/ssh/umac.h"
-#if defined(PR_USE_OPENSSL)
-# include <openssl/aes.h>
-# include <openssl/crypto.h>
-#endif /* PR_USE_OPENSSL */
 #include <string.h>
 #include <stdlib.h>
 #include <stddef.h>
+#include <openssl/aes.h>
+#include <openssl/crypto.h>
 
 #if OPENSSL_VERSION_NUMBER > 0x000907000L 
 

--- a/lib/proxy/ssh/utf8.c
+++ b/lib/proxy/ssh/utf8.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy SSH UTF8 encoding
- * Copyright (c) 2021 TJ Saunders
+ * Copyright (c) 2021-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -92,7 +92,6 @@ static int utf8_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
 }
 #endif /* !PR_USE_NLS && !HAVE_ICONV_H */
 
-#if defined(PR_USE_OPENSSL)
 int proxy_ssh_utf8_set_charset(const char *charset) {
   int res;
 
@@ -329,4 +328,3 @@ char *proxy_ssh_utf8_encode_text(pool *p, const char *text) {
   return pstrdup(p, text);
 #endif /* !PR_USE_NLS && !HAVE_ICONV_H */
 }
-#endif /* PR_USE_OPENSSL */

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -38,7 +38,6 @@
 
 static const char *trace_channel = "proxy.tls";
 
-#if defined(PR_USE_OPENSSL)
 extern xaset_t *server_list;
 
 static unsigned long tls_opts = 0UL;
@@ -2267,12 +2266,12 @@ static int set_next_protocol(SSL_CTX *ctx) {
 
 # if defined(PR_USE_OPENSSL_NPN)
   SSL_CTX_set_next_proto_select_cb(ctx, tls_npn_cb, next_proto);
-# endif /* NPN */
+# endif /* PR_USE_OPENSSL_NPN */
 
 # if defined(PR_USE_OPENSSL_ALPN)
   SSL_CTX_set_alpn_protos(ctx, next_proto->encoded_proto,
     next_proto->encoded_protolen);
-# endif /* ALPN */
+# endif /* PR_USE_OPENSSL_ALPN */
 
   return 0;
 }
@@ -2333,7 +2332,7 @@ static int init_ssl_ctx(void) {
 # if defined(SSL_OP_SAFARI_ECDHE_ECDSA_BUG)
   ssl_opts |= SSL_OP_SAFARI_ECDHE_ECDSA_BUG;
 # endif
-#endif /* ECC support */
+#endif /* PR_USE_OPENSSL_ECC */
 
   SSL_CTX_set_options(ssl_ctx, ssl_opts);
 
@@ -2356,23 +2355,17 @@ static int init_ssl_ctx(void) {
 static void proxy_tls_shutdown_ev(const void *event_data, void *user_data) {
   RAND_cleanup();
 }
-#endif /* PR_USE_OPENSSL */
 
 int proxy_tls_set_data_prot(int data_prot) {
   int old_data_prot;
 
-#if defined(PR_USE_OPENSSL)
   old_data_prot = tls_need_data_prot;
   tls_need_data_prot = data_prot;
-#else
-  old_data_prot = FALSE;
-#endif /* PR_USE_OPENSSL */
 
   return old_data_prot;
 }
 
 int proxy_tls_set_tls(int engine) {
-#if defined(PR_USE_OPENSSL)
   if (engine != PROXY_TLS_ENGINE_ON &&
       engine != PROXY_TLS_ENGINE_OFF &&
       engine != PROXY_TLS_ENGINE_AUTO &&
@@ -2382,17 +2375,11 @@ int proxy_tls_set_tls(int engine) {
   }
 
   tls_engine = engine;
-#endif /* PR_USE_OPENSSL */
-
   return 0;
 }
 
 int proxy_tls_using_tls(void) {
-#if defined(PR_USE_OPENSSL)
   return tls_engine;
-#else
-  return PROXY_TLS_ENGINE_OFF;
-#endif /* PR_USE_OPENSSL */
 }
 
 int proxy_tls_match_client_tls(void) {
@@ -2451,7 +2438,6 @@ int proxy_tls_match_client_tls(void) {
 }
 
 int proxy_tls_init(pool *p, const char *tables_path, int flags) {
-#if defined(PR_USE_OPENSSL)
   int res;
 
   memset(&tls_ds, 0, sizeof(tls_ds));
@@ -2502,7 +2488,6 @@ int proxy_tls_init(pool *p, const char *tables_path, int flags) {
 
   pr_event_register(&proxy_module, "core.shutdown", proxy_tls_shutdown_ev,
     NULL);
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }
@@ -2513,7 +2498,6 @@ int proxy_tls_free(pool *p) {
     return -1;
   }
 
-#if defined(PR_USE_OPENSSL)
   if (ssl_ctx != NULL) {
     SSL_CTX_free(ssl_ctx);
     ssl_ctx = NULL;
@@ -2530,12 +2514,10 @@ int proxy_tls_free(pool *p) {
 
     tls_ds.dsh = NULL;
   }
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }
 
-#if defined(PR_USE_OPENSSL)
 /* Construct the options value that disables all unsupported protocols. */
 static int get_disabled_protocols(unsigned int supported_protocols) {
   int disabled_protocols;
@@ -2617,7 +2599,7 @@ static const char *get_enabled_protocols_str(pool *p, unsigned int protos,
   return proto_str;
 }
 
-# if defined(PSK_MAX_PSK_LEN)
+#if defined(PSK_MAX_PSK_LEN)
 static int tls_load_psk(const char *identity, const char *path) {
   register int i;
   char key_buf[PR_TUNABLE_BUFFER_SIZE];
@@ -2749,7 +2731,7 @@ static int tls_load_psk(const char *identity, const char *path) {
   tls_psk_bn = bn;
   return 0;
 }
-# endif /* PSK support */
+#endif /* PSK support */
 
 static void tls_info_cb(const SSL *ssl, int where, int ret) {
   const char *str = "(unknown)";
@@ -2770,11 +2752,11 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
 
     ssl_state = SSL_get_state(ssl);
     switch (ssl_state) {
-# if defined(SSL_ST_BEFORE)
+#if defined(SSL_ST_BEFORE)
       case SSL_ST_BEFORE:
         str = "before";
         break;
-# endif
+#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
@@ -2785,11 +2767,11 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
         str = "ok";
         break;
 
-# if defined(SSL_ST_RENEGOTIATE)
+#if defined(SSL_ST_RENEGOTIATE)
       case SSL_ST_RENEGOTIATE:
         str = "renegotiating";
         break;
-# endif
+#endif
 
       default:
         break;
@@ -2851,7 +2833,7 @@ static void tls_info_cb(const SSL *ssl, int where, int ret) {
   }
 }
 
-# if OPENSSL_VERSION_NUMBER > 0x000907000L
+#if OPENSSL_VERSION_NUMBER > 0x000907000L
 
 /* Borrowed from mod_tls.  Would be nice to share this code somehow. */
 
@@ -3151,7 +3133,7 @@ static struct tls_label tls_extension_labels[] = {
   { 0, NULL }
 };
 
-# if defined(TLSEXT_TYPE_signature_algorithms)
+#if defined(TLSEXT_TYPE_signature_algorithms)
 /* Signature Algorithms.  These values come from:
  *   https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-16
  */
@@ -3182,9 +3164,9 @@ static struct tls_label tls_sigalgo_labels[] = {
 
   { 0, NULL }
 };
-# endif /* TLSEXT_TYPE_signature_algorithms */
+#endif /* TLSEXT_TYPE_signature_algorithms */
 
-# if defined(TLSEXT_TYPE_psk_kex_modes)
+#if defined(TLSEXT_TYPE_psk_kex_modes)
 /* PSK KEX modes.  These values come from:
  *   https://tools.ietf.org/html/rfc8446#section-4.2.9
  */
@@ -3194,7 +3176,7 @@ static struct tls_label tls_psk_kex_labels[] = {
 
   { 0, NULL }
 };
-# endif /* TLSEXT_TYPE_psk_kex_modes */
+#endif /* TLSEXT_TYPE_psk_kex_modes */
 
 static const char *tls_get_label(int labelno, struct tls_label *labels) {
   register unsigned int i;
@@ -3505,7 +3487,7 @@ static void tls_print_server_hello(int io_flag, int version, int content_type,
   BIO_free(bio);
 }
 
-# if defined(SSL3_MT_NEWSESSION_TICKET)
+#if defined(SSL3_MT_NEWSESSION_TICKET)
 static void tls_print_ticket(int io_flag, int version, int content_type,
     const unsigned char *buf, size_t buflen, SSL *ssl, void *arg) {
   BIO *bio;
@@ -3524,12 +3506,12 @@ static void tls_print_ticket(int io_flag, int version, int content_type,
     buflen -= 4;
     BIO_printf(bio, "  ticket_lifetime_hint\n    %u (sec)\n", ticket_lifetime);
 
-#  if defined(TLS1_3_VERSION)
+# if defined(TLS1_3_VERSION)
     if (SSL_version(ssl) == TLS1_3_VERSION) {
       print_ticket_age = TRUE;
       print_extensions = TRUE;
     }
-#  endif /* TLS1_3_VERSION */
+# endif /* TLS1_3_VERSION */
 
     if (print_ticket_age == TRUE) {
       unsigned int ticket_age_add;
@@ -3560,7 +3542,7 @@ static void tls_print_ticket(int io_flag, int version, int content_type,
 
   BIO_free(bio);
 }
-# endif /* SSL3_MT_NEWSESSION_TICKET */
+#endif /* SSL3_MT_NEWSESSION_TICKET */
 
 #if !defined(OPENSSL_NO_TLSEXT)
 static void tls_tlsext_cb(SSL *ssl, int server, int type,
@@ -4009,26 +3991,26 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
       version_str = "TLSv1";
       break;
 
-#  if defined(TLS1_1_VERSION)
+# if defined(TLS1_1_VERSION)
     case TLS1_1_VERSION:
       version_str = "TLSv1.1";
       break;
-#  endif /* TLS1_1_VERSION */
+# endif /* TLS1_1_VERSION */
 
-#  if defined(TLS1_2_VERSION)
+# if defined(TLS1_2_VERSION)
     case TLS1_2_VERSION:
       version_str = "TLSv1.2";
       break;
-#  endif /* TLS1_2_VERSION */
+# endif /* TLS1_2_VERSION */
 
-#  if defined(TLS1_3_VERSION)
+# if defined(TLS1_3_VERSION)
     case TLS1_3_VERSION:
       version_str = "TLSv1.3";
       break;
-#  endif /* TLS1_3_VERSION */
+# endif /* TLS1_3_VERSION */
 
     default:
-#  if defined(SSL3_RT_HEADER)
+# if defined(SSL3_RT_HEADER)
       /* OpenSSL calls this callback for SSL records received; filter those
        * from true "unknowns".
        */
@@ -4038,23 +4020,23 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
         (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
           "[tls.msg] unknown/unsupported version: %d", version);
       }
-#  else
+# else
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
         "[tls.msg] unknown/unsupported version: %d", version);
-#  endif
+# endif
       break;
   }
 
   if (version == SSL3_VERSION ||
-#  if defined(TLS1_1_VERSION)
+# if defined(TLS1_1_VERSION)
       version == TLS1_1_VERSION ||
-#  endif /* TLS1_1_VERSION */
-#  if defined(TLS1_2_VERSION)
+# endif /* TLS1_1_VERSION */
+# if defined(TLS1_2_VERSION)
       version == TLS1_2_VERSION ||
-#  endif /* TLS1_2_VERSION */
-#  if defined(TLS1_3_VERSION)
+# endif /* TLS1_2_VERSION */
+# if defined(TLS1_3_VERSION)
       version == TLS1_3_VERSION ||
-#  endif /* TLS1_3_VERSION */
+# endif /* TLS1_3_VERSION */
       version == TLS1_VERSION) {
 
     switch (content_type) {
@@ -4134,50 +4116,50 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
                 (unsigned int) buflen, bytes_str);
               break;
 
-#  if defined(SSL3_AD_BAD_CERTIFICATE)
+# if defined(SSL3_AD_BAD_CERTIFICATE)
             case SSL3_AD_BAD_CERTIFICATE:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s %s 'bad_certificate' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
                 (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_AD_BAD_CERTIFICATE */
+# endif /* SSL3_AD_BAD_CERTIFICATE */
 
-#  if defined(SSL3_AD_CERTIFICATE_REVOKED)
+# if defined(SSL3_AD_CERTIFICATE_REVOKED)
             case SSL3_AD_CERTIFICATE_REVOKED:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s %s 'certificate_revoked' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
                 (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_AD_CERTIFICATE_REVOKED */
+# endif /* SSL3_AD_CERTIFICATE_REVOKED */
 
-#  if defined(SSL3_AD_CERTIFICATE_EXPIRED)
+# if defined(SSL3_AD_CERTIFICATE_EXPIRED)
             case SSL3_AD_CERTIFICATE_EXPIRED:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s %s 'certificate_expired' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
                 (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_AD_CERTIFICATE_EXPIRED */
+# endif /* SSL3_AD_CERTIFICATE_EXPIRED */
 
-#  if defined(SSL3_AD_CERTIFICATE_UNKNOWN)
+# if defined(SSL3_AD_CERTIFICATE_UNKNOWN)
             case SSL3_AD_CERTIFICATE_UNKNOWN:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s %s 'certificate_unknown' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
                 (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_AD_CERTIFICATE_UNKNOWN */
+# endif /* SSL3_AD_CERTIFICATE_UNKNOWN */
 
-#  if defined(SSL3_AD_ILLEGAL_PARAMETER)
+# if defined(SSL3_AD_ILLEGAL_PARAMETER)
             case SSL3_AD_ILLEGAL_PARAMETER:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s %s 'illegal_parameter' Alert message "
                 "(%u %s)", action_str, version_str, severity_str,
                 (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_AD_ILLEGAL_PARAMETER */
+# endif /* SSL3_AD_ILLEGAL_PARAMETER */
           }
 
         } else {
@@ -4235,7 +4217,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               break;
             }
 
-#  if defined(SSL3_MT_NEWSESSION_TICKET)
+# if defined(SSL3_MT_NEWSESSION_TICKET)
             case SSL3_MT_NEWSESSION_TICKET: {
               const unsigned char *msg;
               size_t msglen;
@@ -4251,7 +4233,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
 
               break;
             }
-#  endif /* SSL3_MT_NEWSESSION_TICKET */
+# endif /* SSL3_MT_NEWSESSION_TICKET */
 
             case SSL3_MT_CERTIFICATE:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -4299,15 +4281,15 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
                 action_str, version_str, (unsigned int) buflen, bytes_str);
               break;
 
-#  if defined(SSL3_MT_CERTIFICATE_STATUS)
+# if defined(SSL3_MT_CERTIFICATE_STATUS)
             case SSL3_MT_CERTIFICATE_STATUS:
               (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
                 "[tls.msg] %s %s 'CertificateStatus' Handshake message (%u %s)",
                 action_str, version_str, (unsigned int) buflen, bytes_str);
               break;
-#  endif /* SSL3_MT_CERTIFICATE_STATUS */
+# endif /* SSL3_MT_CERTIFICATE_STATUS */
 
-#  if defined(SSL3_MT_ENCRYPTED_EXTENSIONS)
+# if defined(SSL3_MT_ENCRYPTED_EXTENSIONS)
             case SSL3_MT_ENCRYPTED_EXTENSIONS: {
               const unsigned char *msg;
               size_t msglen;
@@ -4340,7 +4322,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
               BIO_free(bio);
               break;
             }
-#  endif /* SSL3_MT_ENCRYPTED_EXTENSIONS */
+# endif /* SSL3_MT_ENCRYPTED_EXTENSIONS */
           }
 
         } else {
@@ -4357,7 +4339,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
         break;
     }
 
-#  if defined(SSL3_RT_HEADER)
+# if defined(SSL3_RT_HEADER)
   } else if (version == 0 &&
              content_type == SSL3_RT_HEADER &&
              buflen == SSL3_RT_HEADER_LENGTH) {
@@ -4372,7 +4354,7 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
     (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
       "[tls.msg] %s protocol record message (content_type = %s, len = %u)",
       action_str, record_type, msg_len);
-#  endif
+# endif
 
   } else {
     /* This case might indicate an issue with OpenSSL itself; the version
@@ -4385,11 +4367,9 @@ static void tls_msg_cb(int io_flag, int version, int content_type,
       action_str, version, content_type, (unsigned int) buflen, bytes_str);
   }
 }
-# endif /* OpenSSL-0.9.7 or later */
-#endif /* PR_USE_OPENSSL */
+#endif /* OpenSSL-0.9.7 or later */
 
 int proxy_tls_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
-#if defined(PR_USE_OPENSSL)
   config_rec *c;
   unsigned int enabled_proto_count = 0, tls_protocol = PROXY_TLS_PROTO_DEFAULT;
   int disabled_proto, res, xerrno = 0;
@@ -4566,12 +4546,12 @@ int proxy_tls_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
 # endif
 #endif
 
-# if defined(X509_V_FLAG_TRUSTED_FIRST)
+#if defined(X509_V_FLAG_TRUSTED_FIRST)
     verify_flags |= X509_V_FLAG_TRUSTED_FIRST;
-# endif
-# if defined(X509_V_FLAG_PARTIAL_CHAIN)
+#endif
+#if defined(X509_V_FLAG_PARTIAL_CHAIN)
     verify_flags |= X509_V_FLAG_PARTIAL_CHAIN;
-# endif
+#endif
 
     if (X509_VERIFY_PARAM_set_flags(verify_param, verify_flags) != 1) {
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
@@ -4690,7 +4670,7 @@ int proxy_tls_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
     }
   }
 
-# if defined(PSK_MAX_PSK_LEN)
+#if defined(PSK_MAX_PSK_LEN)
   c = find_config(main_server->conf, CONF_PARAM, "ProxyTLSPreSharedKey", FALSE);
   if (c != NULL) {
     const char *identity, *path;
@@ -4716,23 +4696,23 @@ int proxy_tls_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
       "enabling support for PSK identities");
     SSL_CTX_set_psk_client_callback(ssl_ctx, tls_psk_cb);
   }
-# endif /* PSK support */
+#endif /* PSK support */
 
-# if !defined(OPENSSL_NO_TLSEXT) && defined(TLSEXT_STATUSTYPE_ocsp)
+#if !defined(OPENSSL_NO_TLSEXT) && defined(TLSEXT_STATUSTYPE_ocsp)
   SSL_CTX_set_tlsext_status_cb(ssl_ctx, tls_ocsp_response_cb);
-# endif /* OCSP support */
+#endif /* OCSP support */
 
   if (tls_opts & PROXY_TLS_OPT_ALLOW_WEAK_SECURITY) {
-# if OPENSSL_VERSION_NUMBER >= 0x10100000L
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
     SSL_CTX_set_security_level(ssl_ctx, 0);
-# endif /* OpenSSL-1.1.0 and later */
+#endif /* OpenSSL-1.1.0 and later */
   }
 
   if (tls_opts & PROXY_TLS_OPT_ENABLE_DIAGS) {
     SSL_CTX_set_info_callback(ssl_ctx, tls_info_cb);
-# if OPENSSL_VERSION_NUMBER > 0x000907000L
+#if OPENSSL_VERSION_NUMBER > 0x000907000L
     SSL_CTX_set_msg_callback(ssl_ctx, tls_msg_cb);
-# endif
+#endif
   }
 
   if (netio_install_ctrl() < 0) {
@@ -4744,7 +4724,6 @@ int proxy_tls_sess_init(pool *p, struct proxy_session *proxy_sess, int flags) {
     errno = xerrno;
     return -1;
   }
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }
@@ -4755,7 +4734,6 @@ int proxy_tls_sess_free(pool *p) {
     return -1;
   }
 
-#if defined(PR_USE_OPENSSL)
   /* Reset any state, but only if we have not already negotiated an SSL
    * session.
    */
@@ -4767,16 +4745,16 @@ int proxy_tls_sess_free(pool *p) {
     tls_engine = PROXY_TLS_ENGINE_AUTO;
     tls_verify_server = TRUE;
     tls_cipher_suite = NULL;
-# if OPENSSL_VERSION_NUMBER >= 0x10101000L && \
+#if OPENSSL_VERSION_NUMBER >= 0x10101000L && \
      defined(TLS1_3_VERSION)
     tlsv13_cipher_suite = NULL;
-# endif /* TLS1_3_VERSION */
+#endif /* TLS1_3_VERSION */
 
-# if defined(PSK_MAX_PSK_LEN)
+#if defined(PSK_MAX_PSK_LEN)
     tls_psk_name = NULL;
     tls_psk_bn = NULL;
     tls_psk_used = FALSE;
-# endif /* PSK support */
+#endif /* PSK support */
 
     if (tls_ds.dsh != NULL) {
       (void) (tls_ds.close)(p, tls_ds.dsh);
@@ -4802,7 +4780,6 @@ int proxy_tls_sess_free(pool *p) {
       tls_ctrl_netio = NULL;
     }
   }
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }

--- a/lib/proxy/tls/db.c
+++ b/lib/proxy/tls/db.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy TLS Database implementation
- * Copyright (c) 2017-2021 TJ Saunders
+ * Copyright (c) 2017-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 #include "proxy/db.h"
 #include "proxy/tls.h"
 #include "proxy/tls/db.h"
-
-#ifdef PR_USE_OPENSSL
 
 extern xaset_t *server_list;
 
@@ -478,7 +476,6 @@ static void *tls_db_open(pool *p, const char *tables_dir, unsigned long opts) {
   db_opts = opts;
   return dbh;
 }
-#endif /* PR_USE_OPENSSL */
 
 int proxy_tls_db_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
     size_t ds_datasz) {
@@ -490,7 +487,6 @@ int proxy_tls_db_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
   (void) ds_data;
   (void) ds_datasz;
 
-#ifdef PR_USE_OPENSSL
   ds->add_sess = tls_db_add_sess;
   ds->remove_sess = tls_db_remove_sess;
   ds->get_sess = tls_db_get_sess;
@@ -499,7 +495,6 @@ int proxy_tls_db_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
   ds->init = tls_db_init;
   ds->open = tls_db_open;
   ds->close = tls_db_close;
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }

--- a/lib/proxy/tls/redis.c
+++ b/lib/proxy/tls/redis.c
@@ -1,6 +1,6 @@
 /*
  * ProFTPD - mod_proxy TLS Redis implementation
- * Copyright (c) 2017-2020 TJ Saunders
+ * Copyright (c) 2017-2025 TJ Saunders
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 #include "redis.h"
 #include "proxy/tls.h"
 #include "proxy/tls/redis.h"
-
-#ifdef PR_USE_OPENSSL
 
 extern xaset_t *server_list;
 
@@ -347,7 +345,6 @@ static void *tls_redis_open(pool *p, const char *tables_dir,
   redis_opts = opts;
   return redis;
 }
-#endif /* PR_USE_OPENSSL */
 
 int proxy_tls_redis_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
     size_t ds_datasz) {
@@ -356,7 +353,6 @@ int proxy_tls_redis_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
     return -1;
   }
 
-#ifdef PR_USE_OPENSSL
   redis_prefix = ds_data;
   redis_prefixsz = ds_datasz;
 
@@ -368,7 +364,6 @@ int proxy_tls_redis_as_datastore(struct proxy_tls_datastore *ds, void *ds_data,
   ds->init = tls_redis_init;
   ds->open = tls_redis_open;
   ds->close = tls_redis_close;
-#endif /* PR_USE_OPENSSL */
 
   return 0;
 }

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -1031,7 +1031,6 @@ MODRET set_proxyrole(cmd_rec *cmd) {
 
 /* usage: ProxySFTPCiphers algos */
 MODRET set_proxysftpciphers(cmd_rec *cmd) {
-#if defined(PR_USE_OPENSSL)
   register unsigned int i;
   config_rec *c;
 
@@ -1054,10 +1053,6 @@ MODRET set_proxysftpciphers(cmd_rec *cmd) {
   }
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd,
-    "Use of the ProxySFTPCiphers directive requires OpenSSL support (--enable-openssl)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxySFTPCompression on|off|delayed */
@@ -1096,7 +1091,6 @@ MODRET set_proxysftpcompression(cmd_rec *cmd) {
 
 /* usage: ProxySFTPDigests algos */
 MODRET set_proxysftpdigests(cmd_rec *cmd) {
-#if defined(PR_USE_OPENSSL)
   register unsigned int i;
   config_rec *c;
 
@@ -1119,10 +1113,6 @@ MODRET set_proxysftpdigests(cmd_rec *cmd) {
   }
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd,
-    "Use of the ProxySFTPDigests directive requires OpenSSL support (--enable-openssl)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxySFTPHostKey path|"agent:/..." */
@@ -1174,7 +1164,6 @@ MODRET set_proxysftphostkey(cmd_rec *cmd) {
 
 /* usage: ProxySFTPKeyExchanges algos */
 MODRET set_proxysftpkeyexchanges(cmd_rec *cmd) {
-#if defined(PR_USE_OPENSSL)
   register unsigned int i;
   config_rec *c;
   char *exchanges = "";
@@ -1223,10 +1212,6 @@ MODRET set_proxysftpkeyexchanges(cmd_rec *cmd) {
   c->argv[0] = exchanges;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd,
-    "Use of the ProxySFTPKeyExchanges directive requires OpenSSL support (--enable-openssl)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxySFTPOptions opts */
@@ -1629,7 +1614,6 @@ MODRET set_proxytimeoutlinger(cmd_rec *cmd) {
 
 /* usage: ProxyTLSCACertificateFile path */
 MODRET set_proxytlscacertfile(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1653,14 +1637,10 @@ MODRET set_proxytlscacertfile(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCACertificatePath path */
 MODRET set_proxytlscacertpath(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1683,14 +1663,10 @@ MODRET set_proxytlscacertpath(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCARevocationFile path */
 MODRET set_proxytlscacrlfile(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1714,14 +1690,10 @@ MODRET set_proxytlscacrlfile(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCARevocationPath path */
 MODRET set_proxytlscacrlpath(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1744,14 +1716,10 @@ MODRET set_proxytlscacrlpath(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCertificateFile path */
 MODRET set_proxytlscertfile(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1775,14 +1743,10 @@ MODRET set_proxytlscertfile(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCertificateKeyFile path */
 MODRET set_proxytlscertkeyfile(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int res;
   char *path;
 
@@ -1806,14 +1770,10 @@ MODRET set_proxytlscertkeyfile(cmd_rec *cmd) {
 
   add_config_param_str(cmd->argv[0], 1, path);
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSCipherSuite [protocol] ciphers */
 MODRET set_proxytlsciphersuite(cmd_rec *cmd) {
-#if defined(PR_USE_OPENSSL)
   config_rec *c = NULL;
   char *ciphersuite = NULL;
   int protocol = 0;
@@ -1917,14 +1877,10 @@ MODRET set_proxytlsciphersuite(cmd_rec *cmd) {
   }
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSEngine on|off|auto|MatchClient */
 MODRET set_proxytlsengine(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int engine = -1;
   config_rec *c;
 
@@ -1958,14 +1914,10 @@ MODRET set_proxytlsengine(cmd_rec *cmd) {
   *((int *) c->argv[0]) = engine;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSOptions ... */
 MODRET set_proxytlsoptions(cmd_rec *cmd) {
-#if defined(PR_USE_OPENSSL)
   config_rec *c = NULL;
   register unsigned int i = 0;
   unsigned long opts = 0UL;
@@ -2014,15 +1966,11 @@ MODRET set_proxytlsoptions(cmd_rec *cmd) {
   }
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSPreSharedKey name path */
 MODRET set_proxytlspresharedkey(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
-# if defined(PSK_MAX_PSK_LEN)
+#if defined(PSK_MAX_PSK_LEN)
   size_t identity_len, path_len;
   char *path;
 
@@ -2054,20 +2002,17 @@ MODRET set_proxytlspresharedkey(cmd_rec *cmd) {
   }
 
   (void) add_config_param_str(cmd->argv[0], 2, cmd->argv[1], path);
-# else
+#else
   pr_log_debug(DEBUG0,
     "%s is not supported by this build/version of OpenSSL, ignoring",
     (char *) cmd->argv[0]);
-# endif /* PSK support */
+#endif /* PSK support */
+
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSProtocol protocols */
 MODRET set_proxytlsprotocol(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   register unsigned int i;
   config_rec *c;
   unsigned int tls_protocol = 0;
@@ -2119,37 +2064,37 @@ MODRET set_proxytlsprotocol(cmd_rec *cmd) {
         }
 
       } else if (strcasecmp(proto_name, "TLSv1.1") == 0) {
-# if defined(TLS1_1_VERSION)
+#if defined(TLS1_1_VERSION)
         if (disable) {
           tls_protocol &= ~PROXY_TLS_PROTO_TLS_V1_1;
         } else {
           tls_protocol |= PROXY_TLS_PROTO_TLS_V1_1;
         }
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.1");
-# endif /* OpenSSL 1.0.1 or later */
+#endif /* OpenSSL 1.0.1 or later */
 
       } else if (strcasecmp(proto_name, "TLSv1.2") == 0) {
-# if defined(TLS1_2_VERSION)
+#if defined(TLS1_2_VERSION)
         if (disable) {
           tls_protocol &= ~PROXY_TLS_PROTO_TLS_V1_2;
         } else {
           tls_protocol |= PROXY_TLS_PROTO_TLS_V1_2;
         }
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.2");
-# endif /* OpenSSL 1.0.1 or later */
+#endif /* OpenSSL 1.0.1 or later */
 
       } else if (strcasecmp(proto_name, "TLSv1.3") == 0) {
-# if defined(TLS1_3_VERSION)
+#if defined(TLS1_3_VERSION)
         if (disable) {
           tls_protocol &= ~PROXY_TLS_PROTO_TLS_V1_3;
         } else {
           tls_protocol |= PROXY_TLS_PROTO_TLS_V1_3;
         }
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.3");
-# endif /* OpenSSL 1.1.1 or later */
+#endif /* OpenSSL 1.1.1 or later */
 
       } else {
         CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unknown protocol: '",
@@ -2171,25 +2116,25 @@ MODRET set_proxytlsprotocol(cmd_rec *cmd) {
         tls_protocol |= PROXY_TLS_PROTO_TLS_V1;
 
       } else if (strcasecmp(cmd->argv[i], "TLSv1.1") == 0) {
-# if defined(TLS1_1_VERSION)
+#if defined(TLS1_1_VERSION)
         tls_protocol |= PROXY_TLS_PROTO_TLS_V1_1;
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.1");
-# endif /* OpenSSL 1.0.1 or later */
+#endif /* OpenSSL 1.0.1 or later */
 
       } else if (strcasecmp(cmd->argv[i], "TLSv1.2") == 0) {
-# if defined(TLS1_2_VERSION)
+#if defined(TLS1_2_VERSION)
         tls_protocol |= PROXY_TLS_PROTO_TLS_V1_2;
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.2");
-# endif /* OpenSSL 1.0.1 or later */
+#endif /* OpenSSL 1.0.1 or later */
 
       } else if (strcasecmp(cmd->argv[i], "TLSv1.3") == 0) {
-# if defined(TLS1_3_VERSION)
+#if defined(TLS1_3_VERSION)
         tls_protocol |= PROXY_TLS_PROTO_TLS_V1_3;
-# else
+#else
         CONF_ERROR(cmd, "Your OpenSSL installation does not support TLSv1.3");
-# endif /* OpenSSL 1.1.1 or later */
+#endif /* OpenSSL 1.1.1 or later */
 
       } else {
         CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "unknown protocol: '",
@@ -2203,14 +2148,10 @@ MODRET set_proxytlsprotocol(cmd_rec *cmd) {
   *((unsigned int *) c->argv[0]) = tls_protocol;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSTimeoutHandshake timeout */
 MODRET set_proxytlstimeouthandshake(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int timeout = -1;
   config_rec *c = NULL;
 
@@ -2227,14 +2168,10 @@ MODRET set_proxytlstimeouthandshake(cmd_rec *cmd) {
   *((unsigned int *) c->argv[0]) = timeout;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSTransferProtectionPolicy client|required|clear */
 MODRET set_proxytlsxferprotpolicy(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   config_rec *c;
   const char *policy;
   int require_prot = 0;
@@ -2262,14 +2199,10 @@ MODRET set_proxytlsxferprotpolicy(cmd_rec *cmd) {
   *((int *) c->argv[0]) = require_prot;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 /* usage: ProxyTLSVerifyServer on|off */
 MODRET set_proxytlsverifyserver(cmd_rec *cmd) {
-#ifdef PR_USE_OPENSSL
   int verify = -1;
   config_rec *c = NULL;
 
@@ -2286,9 +2219,6 @@ MODRET set_proxytlsverifyserver(cmd_rec *cmd) {
   *((int *) c->argv[0]) = verify;
 
   return PR_HANDLED(cmd);
-#else
-  CONF_ERROR(cmd, "Missing required OpenSSL support (see --enable-openssl configure option)");
-#endif /* PR_USE_OPENSSL */
 }
 
 static void proxy_process_cmd(void) {


### PR DESCRIPTION
…the `#ifdef PR_USE_OPENSSL` support throughout the code base.  And this also makes for a clearer build failure when OpenSSL support is lacking.