### PR TITLE
fix: add sanity check for SRV record lengths in dns.c

### DIFF
--- a/lib/proxy/dns.c
+++ b/lib/proxy/dns.c
@@ -449,6 +449,12 @@ static int dns_resolve_srv(pool *p, const char *name, array_header **resp,
     if (expanded_namelen < 0) {
       /* Assume the target name was properly NOT compressed. */
       target_len = ns_rr_rdlen(record) - offset;
+      if (target_len == 0 || target_len > NS_MAXDNAME) {
+        pr_trace_msg(trace_channel, 3,
+          "invalid SRV target length %lu for record #%u, skipping",
+          (unsigned long) target_len, i + 1);
+        continue;
+      }
       target_text = pcalloc(srv_pool, target_len + 1);
       memcpy(target_text, (unsigned char *) ns_rr_rdata(record) + offset,
         target_len);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `lib/proxy/dns.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/proxy/dns.c:452` |
| **CWE** | CWE-190 |

**Description**: DNS record length values (target_len, record_len) from external DNS responses are used in allocation size calculations with +1 for null terminator. If a malicious DNS server returns crafted SRV records with length values near the maximum integer value, the addition of 1 causes integer overflow, resulting in a near-zero allocation. Subsequent copy of DNS record data into this undersized buffer causes a heap overflow that could enable remote code execution.

## Changes
- `lib/proxy/dns.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
