### PR TITLE
Issue #325: When freeing up the cipher/HMAC resources used for SSH su…

### DIFF
--- a/lib/proxy/ssh/cipher.c
+++ b/lib/proxy/ssh/cipher.c
@@ -1606,27 +1606,46 @@ int proxy_ssh_cipher_init(void) {
 
 int proxy_ssh_cipher_free(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x1000000fL
-  EVP_CIPHER_CTX_free(read_ctxs[0]);
-  EVP_CIPHER_CTX_free(read_ctxs[1]);
-  EVP_CIPHER_CTX_free(write_ctxs[0]);
-  EVP_CIPHER_CTX_free(write_ctxs[1]);
+  if (read_ctxs[0] != NULL) {
+    EVP_CIPHER_CTX_free(read_ctxs[0]);
+    read_ctxs[0] = NULL;
+  }
+
+  if (read_ctxs[1] != NULL) {
+    EVP_CIPHER_CTX_free(read_ctxs[1]);
+    read_ctxs[1] = NULL;
+  }
+
+  if (write_ctxs[0] != NULL) {
+    EVP_CIPHER_CTX_free(write_ctxs[0]);
+    write_ctxs[0] = NULL;
+  }
+
+  if (write_ctxs[1] != NULL) {
+    EVP_CIPHER_CTX_free(write_ctxs[1]);
+    write_ctxs[1] = NULL;
+  }
 
 # if defined(HAVE_EVP_CHACHA20_OPENSSL) && \
     !defined(HAVE_BROKEN_CHACHA20)
   if (read_header_ctxs[0] != NULL) {
     EVP_CIPHER_CTX_free(read_header_ctxs[0]);
+    read_header_ctxs[0] = NULL;
   }
 
   if (read_header_ctxs[1] != NULL) {
     EVP_CIPHER_CTX_free(read_header_ctxs[1]);
+    read_header_ctxs[1] = NULL;
   }
 
   if (write_header_ctxs[0] != NULL) {
     EVP_CIPHER_CTX_free(write_header_ctxs[0]);
+    write_header_ctxs[0] = NULL;
   }
 
   if (write_header_ctxs[1] != NULL) {
     EVP_CIPHER_CTX_free(write_header_ctxs[1]);
+    write_header_ctxs[1] = NULL;
   }
 # endif /* HAVE_EVP_CHACHA20_OPENSSL and !HAVE_BROKEN_CHACHA20 */
 #endif /* OpenSSL-1.0.0 and later */

--- a/lib/proxy/ssh/mac.c
+++ b/lib/proxy/ssh/mac.c
@@ -1132,10 +1132,25 @@ int proxy_ssh_mac_init(void) {
 int proxy_ssh_mac_free(void) {
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
     !defined(HAVE_LIBRESSL)
-  HMAC_CTX_free(hmac_read_ctxs[0]);
-  HMAC_CTX_free(hmac_read_ctxs[1]);
-  HMAC_CTX_free(hmac_write_ctxs[0]);
-  HMAC_CTX_free(hmac_write_ctxs[1]);
+  if (hmac_read_ctxs[0] != NULL) {
+    HMAC_CTX_free(hmac_read_ctxs[0]);
+    hmac_read_ctxs[0] = NULL;
+  }
+
+  if (hmac_read_ctxs[1] != NULL) {
+    HMAC_CTX_free(hmac_read_ctxs[1]);
+    hmac_read_ctxs[1] = NULL;
+  }
+
+  if (hmac_write_ctxs[0] != NULL) {
+    HMAC_CTX_free(hmac_write_ctxs[0]);
+    hmac_write_ctxs[0] = NULL;
+  }
+
+  if (hmac_write_ctxs[1] != NULL) {
+    HMAC_CTX_free(hmac_write_ctxs[1]);
+    hmac_write_ctxs[1] = NULL;
+  }
 #endif /* OpenSSL-1.1.0 and later */
   return 0;
 }


### PR DESCRIPTION
…pport, make sure we set the pointers to NULL, _and_ check for such NULL pointers _before_ attempting to free those resources again.

Otherwise, we run into double-free territory.