### PR TITLE
Handle the case where mod_proxy is built, but no other OpenSSL-using …

### DIFF
--- a/lib/proxy/ssh.c
+++ b/lib/proxy/ssh.c
@@ -697,17 +697,6 @@ int proxy_ssh_init(pool *p, const char *tables_path, int flags) {
     return -1;
   }
 
-  if (pr_module_exists("mod_sftp.c") == FALSE &&
-      pr_module_exists("mod_tls.c") == FALSE) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    OPENSSL_config(NULL);
-#endif /* prior to OpenSSL-1.1.x */
-    SSL_load_error_strings();
-    SSL_library_init();
-    ERR_load_crypto_strings();
-    OpenSSL_add_all_algorithms();
-  }
-
   ssh_tables_path = pstrdup(proxy_pool, tables_path);
 
   /* Initialize SSH API */

--- a/lib/proxy/tls.c
+++ b/lib/proxy/tls.c
@@ -2492,21 +2492,12 @@ int proxy_tls_init(pool *p, const char *tables_path, int flags) {
     return -1;
   }
 
-  if (pr_module_exists("mod_sftp.c") == FALSE &&
-      pr_module_exists("mod_tls.c") == FALSE) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    OPENSSL_config(NULL);
-#endif /* prior to OpenSSL-1.1.x */
-    SSL_load_error_strings();
-    SSL_library_init();
-    ERR_load_crypto_strings();
-    OpenSSL_add_all_algorithms();
-  }
-
+#if defined(PR_USE_OPENSSL)
   res = init_ssl_ctx();
   if (res < 0) {
     return -1;
   }
+#endif /* PR_USE_OPENSSL */
 
   tls_tables_path = pstrdup(proxy_pool, tables_path);
 
@@ -2522,10 +2513,12 @@ int proxy_tls_free(pool *p) {
     return -1;
   }
 
+#if defined(PR_USE_OPENSSL)
   if (ssl_ctx != NULL) {
     SSL_CTX_free(ssl_ctx);
     ssl_ctx = NULL;
   }
+#endif /* PR_USE_OPENSSL */
 
   if (tls_ds.dsh != NULL) {
     int res;

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -5289,6 +5289,20 @@ static void proxy_postparse_ev(const void *event_data, void *user_data) {
       "Failed reverse proxy initialization");
   }
 
+  /* Deal with initializing OpenSSL, before we initialize our SSH and TLS
+   * APIs, in the event that neither mod_sftp nor mod_tls are present.
+   */
+  if (pr_module_exists("mod_sftp.c") == FALSE &&
+      pr_module_exists("mod_tls.c") == FALSE) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    OPENSSL_config(NULL);
+#endif /* prior to OpenSSL-1.1.x */
+    ERR_load_crypto_strings();
+    OpenSSL_add_all_algorithms();
+    SSL_load_error_strings();
+    SSL_library_init();
+  }
+
   if (proxy_ssh_init(proxy_pool, proxy_tables_dir, 0) < 0) {
     pr_log_pri(PR_LOG_WARNING, MOD_PROXY_VERSION
       ": unable to initialize SSH support, failing to start up: %s",


### PR DESCRIPTION
…modules are.

I ran into this locally, and ProFTPD would fail to start when mod_proxy failed in TLS API initialization with "library has no ciphers" unexpectedly.