### PR TITLE
Use the more verbose/explicit `if defined` preprocessor syntax.

### DIFF
--- a/include/proxy/tls.h
+++ b/include/proxy/tls.h
@@ -42,7 +42,7 @@
 # endif /* PR_USE_OPENSSL_ENGINE */
 # include <openssl/ocsp.h>
 #endif
-#ifdef PR_USE_OPENSSL_ECC
+#if defined(PR_USE_OPENSSL_ECC)
 # include <openssl/ec.h>
 # include <openssl/ecdh.h>
 #endif /* PR_USE_OPENSSL_ECC */

--- a/lib/proxy/conn.c
+++ b/lib/proxy/conn.c
@@ -23,7 +23,7 @@
 
 #include "mod_proxy.h"
 
-#ifdef HAVE_SYS_UIO_H
+#if defined(HAVE_SYS_UIO_H)
 # include <sys/uio.h>
 #endif /* HAVE_SYS_UIO_H */
 

--- a/lib/proxy/forward.c
+++ b/lib/proxy/forward.c
@@ -365,7 +365,7 @@ static int forward_connect(pool *p, struct proxy_session *proxy_sess,
 }
 
 static int forward_dst_filter(pool *p, const char *hostport) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   config_rec *c;
   pr_regex_t *pre;
   int negated = FALSE, res;

--- a/lib/proxy/ftp/msg.c
+++ b/lib/proxy/ftp/msg.c
@@ -106,7 +106,7 @@ const char *proxy_ftp_msg_fmt_ext_addr(pool *p, const pr_netaddr_t *addr,
       family = 1;
       break;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case AF_INET6:
       family = 2;
       break;
@@ -202,14 +202,14 @@ const pr_netaddr_t *proxy_ftp_msg_parse_addr(pool *p, const char *msg,
    */
   addrlen = 16;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   /* Allow extra room for any necessary "::ffff:" prefix, for IPv6 sessions. */
   addrlen += 7;
 #endif /* PR_USE_IPV6 */
 
   addr_buf = pcalloc(p, addrlen);
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   if (pr_netaddr_use_ipv6()) {
     if (addr_family == AF_INET6) {
       snprintf(addr_buf, addrlen, "::ffff:%u.%u.%u.%u", h1, h2, h3, h4);
@@ -321,7 +321,7 @@ const pr_netaddr_t *proxy_ftp_msg_parse_ext_addr(pool *p, const char *msg,
           family = 1;
           break;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
         case AF_INET6:
           if (pr_netaddr_use_ipv6()) {
             family = 2;
@@ -346,7 +346,7 @@ const pr_netaddr_t *proxy_ftp_msg_parse_ext_addr(pool *p, const char *msg,
       pr_trace_msg(trace_channel, 19, "parsed IPv4 address from '%s'", msg);
       break;
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     case 2:
       pr_trace_msg(trace_channel, 19, "parsed IPv6 address from '%s'", msg);
       if (pr_netaddr_use_ipv6()) {

--- a/lib/proxy/ftp/xfer.c
+++ b/lib/proxy/ftp/xfer.c
@@ -160,7 +160,7 @@ int proxy_ftp_xfer_prepare_active(int policy_id, cmd_rec *cmd,
   bind_family = pr_netaddr_get_family(bind_addr);
 
   if (bind_family == backend_family) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     if (pr_netaddr_use_ipv6()) {
       /* Make sure that the family is NOT IPv6, even though the local and
        * remote families match.  The PORT command cannot be used for IPv6

--- a/lib/proxy/random.c
+++ b/lib/proxy/random.c
@@ -30,7 +30,7 @@ static const char *trace_channel = "proxy.random";
  * seeded by the core proftpd code.
  */
 int proxy_random_init(void) {
-#ifdef HAVE_RANDOM
+#if defined(HAVE_RANDOM)
   struct timeval tv;
 
   gettimeofday(&tv, NULL);

--- a/lib/proxy/ssh/cipher.c
+++ b/lib/proxy/ssh/cipher.c
@@ -1493,7 +1493,7 @@ int proxy_ssh_cipher_write_data(struct proxy_ssh_packet *pkt,
 
   *buflen = len;
 
-#ifdef SFTP_DEBUG_PACKET
+#if defined(SFTP_DEBUG_PACKET)
 {
   unsigned int i;
 
@@ -1509,7 +1509,7 @@ int proxy_ssh_cipher_write_data(struct proxy_ssh_packet *pkt,
     i += 8;
   }
 }
-#endif
+#endif /* SFTP_DEBUG_PACKET */
 
   if (auth_len > 0) {
     unsigned char *tag_data = NULL;

--- a/lib/proxy/ssh/crypto.c
+++ b/lib/proxy/ssh/crypto.c
@@ -605,7 +605,7 @@ static const EVP_CIPHER *get_des3_ctr_cipher(void) {
   EVP_CIPHER_meth_set_do_cipher(cipher, do_des3_ctr);
 
   flags = EVP_CIPH_CBC_MODE|EVP_CIPH_VARIABLE_LENGTH|EVP_CIPH_ALWAYS_CALL_INIT|EVP_CIPH_CUSTOM_IV;
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
   flags |= EVP_CIPH_FLAG_FIPS;
 #endif /* OPENSSL_FIPS */
 
@@ -625,7 +625,7 @@ static const EVP_CIPHER *get_des3_ctr_cipher(void) {
   des3_ctr_cipher.do_cipher = do_des3_ctr;
 
   des3_ctr_cipher.flags = EVP_CIPH_CBC_MODE|EVP_CIPH_VARIABLE_LENGTH|EVP_CIPH_ALWAYS_CALL_INIT|EVP_CIPH_CUSTOM_IV;
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
   des3_ctr_cipher.flags |= EVP_CIPH_FLAG_FIPS;
 #endif /* OPENSSL_FIPS */
 
@@ -753,7 +753,7 @@ static int do_aes_ctr(EVP_CIPHER_CTX *ctx, unsigned char *dst,
 static int get_aes_ctr_cipher_nid(int key_len) {
   int nid;
 
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
   /* Set the NID depending on the key len. */
   switch (key_len) {
     case 16:
@@ -824,7 +824,7 @@ static const EVP_CIPHER *get_aes_ctr_cipher(int key_len) {
   EVP_CIPHER_meth_set_do_cipher(cipher, do_aes_ctr);
 
   flags = EVP_CIPH_CBC_MODE|EVP_CIPH_VARIABLE_LENGTH|EVP_CIPH_ALWAYS_CALL_INIT|EVP_CIPH_CUSTOM_IV;
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
   flags |= EVP_CIPH_FLAG_FIPS;
 #endif /* OPENSSL_FIPS */
 
@@ -844,7 +844,7 @@ static const EVP_CIPHER *get_aes_ctr_cipher(int key_len) {
   aes_ctr_cipher.do_cipher = do_aes_ctr;
 
   aes_ctr_cipher.flags = EVP_CIPH_CBC_MODE|EVP_CIPH_VARIABLE_LENGTH|EVP_CIPH_ALWAYS_CALL_INIT|EVP_CIPH_CUSTOM_IV;
-# ifdef OPENSSL_FIPS
+# if defined(OPENSSL_FIPS)
   aes_ctr_cipher.flags |= EVP_CIPH_FLAG_FIPS;
 # endif /* OPENSSL_FIPS */
 
@@ -1248,7 +1248,7 @@ const char *proxy_ssh_crypto_get_kexinit_cipher_list(pool *p) {
 
       for (j = 0; ciphers[j].name; j++) {
         if (strcmp(c->argv[i], ciphers[j].name) == 0) {
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
           if (FIPS_mode()) {
             /* If FIPS mode is enabled, check whether the cipher is allowed
              * for use.
@@ -1277,7 +1277,7 @@ const char *proxy_ssh_crypto_get_kexinit_cipher_list(pool *p) {
 #if defined(HAVE_EVP_AES_256_GCM_OPENSSL)
                   || strcmp(ciphers[j].name, "aes128-gcm@openssh.com") == 0 ||
                   strcmp(ciphers[j].name, "aes256-gcm@openssh.com") == 0
-#endif
+#endif /* HAVE_EVP_AES_256_GCM_OPENSSL */
                   ) {
                 res = pstrcat(p, res, *res ? "," : "",
                   pstrdup(p, ciphers[j].name), NULL);
@@ -1302,7 +1302,7 @@ const char *proxy_ssh_crypto_get_kexinit_cipher_list(pool *p) {
 
     for (i = 0; ciphers[i].name; i++) {
       if (ciphers[i].enabled) {
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
           if (FIPS_mode()) {
             /* If FIPS mode is enabled, check whether the cipher is allowed
              * for use.
@@ -1377,7 +1377,7 @@ const char *proxy_ssh_crypto_get_kexinit_digest_list(pool *p) {
 
       for (j = 0; digests[j].name; j++) {
         if (strcmp(c->argv[i], digests[j].name) == 0) {
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
           if (FIPS_mode()) {
             /* If FIPS mode is enabled, check whether the MAC is allowed
              * for use.
@@ -1426,7 +1426,7 @@ const char *proxy_ssh_crypto_get_kexinit_digest_list(pool *p) {
 
     for (i = 0; digests[i].name; i++) {
       if (digests[i].enabled) {
-#ifdef OPENSSL_FIPS
+#if defined(OPENSSL_FIPS)
           if (FIPS_mode()) {
             /* If FIPS mode is enabled, check whether the digest is allowed
              * for use.
@@ -1584,7 +1584,7 @@ const char *proxy_ssh_crypto_get_errors(void) {
  * sizes by rounding up.
  */
 size_t proxy_ssh_crypto_get_size(size_t first, size_t second) {
-#ifdef roundup
+#if defined(roundup)
   return roundup(first, second);
 #else
   return (((first + (second - 1)) / second) * second);

--- a/lib/proxy/ssh/mac.c
+++ b/lib/proxy/ssh/mac.c
@@ -411,7 +411,7 @@ static int get_mac(struct proxy_ssh_packet *pkt, struct proxy_ssh_mac *mac,
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
         "MAC from server differs from expected MAC using %s", mac->algo);
 
-#ifdef SFTP_DEBUG_PACKET
+#if defined(SFTP_DEBUG_PACKET)
       (void) pr_log_writefile(proxy_logfd, MOD_PROXY_VERSION,
         "client MAC (len %lu):", (unsigned long) pkt->mac_len);
       for (i = 0; i < mac_len;) {
@@ -438,7 +438,7 @@ static int get_mac(struct proxy_ssh_packet *pkt, struct proxy_ssh_mac *mac,
 #else
       /* Avoid compiler warning. */
       (void) i;
-#endif
+#endif /* SFTP_DEBUG_PACKET */
 
       errno = EINVAL;
       return -1;
@@ -446,7 +446,7 @@ static int get_mac(struct proxy_ssh_packet *pkt, struct proxy_ssh_mac *mac,
 
   } else if (flags & PROXY_SSH_MAC_FL_WRITE_MAC) {
     /* Debugging. */
-#ifdef SFTP_DEBUG_PACKET
+#if defined(SFTP_DEBUG_PACKET)
     if (pkt->mac_len > 0) {
       unsigned int i = 0;
 
@@ -463,7 +463,7 @@ static int get_mac(struct proxy_ssh_packet *pkt, struct proxy_ssh_mac *mac,
         i += 8;
       }
     }
-#endif
+#endif /* SFTP_DEBUG_PACKET */
   }
 
   pkt->mac_len = mac_len;

--- a/lib/proxy/ssh/packet.c
+++ b/lib/proxy/ssh/packet.c
@@ -358,13 +358,13 @@ int proxy_ssh_packet_conn_read(conn_t *conn, void *buf, size_t reqlen,
          */
         if (errno == ECONNRESET ||
             errno == ECONNABORTED ||
-#ifdef ETIMEDOUT
+#if defined(ETIMEDOUT)
             errno == ETIMEDOUT ||
 #endif /* ETIMEDOUT */
-#ifdef ENOTCONN
+#if defined(ENOTCONN)
             errno == ENOTCONN ||
 #endif /* ENOTCONN */
-#ifdef ESHUTDOWN
+#if defined(ESHUTDOWN)
             errno == ESHUTDOWN ||
 #endif /* ESHUTDOWNN */
             errno == EPIPE) {

--- a/lib/proxy/ssh/utf8.c
+++ b/lib/proxy/ssh/utf8.c
@@ -41,7 +41,7 @@ static iconv_t encode_conv = (iconv_t) -1;
 
 static int utf8_convert(iconv_t conv, const char *inbuf, size_t *inbuflen,
     char *outbuf, size_t *outbuflen) {
-# ifdef HAVE_ICONV
+# if defined(HAVE_ICONV)
 
   /* Reset the state machine before each conversion. */
   (void) iconv(conv, NULL, NULL, NULL, NULL);

--- a/mod_proxy.c
+++ b/mod_proxy.c
@@ -564,7 +564,7 @@ MODRET set_proxydatastore(cmd_rec *cmd) {
     ds_data = NULL;
     ds_datasz = 0;
 
-#ifdef PR_USE_REDIS
+#if defined(PR_USE_REDIS)
   } else if (strcasecmp(ds_name, "redis") == 0) {
     if (cmd->argc != 3) {
       CONF_ERROR(cmd, "missing required Redis key prefix");
@@ -701,7 +701,7 @@ MODRET set_proxyforwardmethod(cmd_rec *cmd) {
 
 /* usage: ProxyForwardTo [!]pattern [flags] */
 MODRET set_proxyforwardto(cmd_rec *cmd) {
-#ifdef PR_USE_REGEX
+#if defined(PR_USE_REGEX)
   config_rec *c;
   pr_regex_t *pre = NULL;
   int negated = FALSE, regex_flags = REG_EXTENDED|REG_NOSUB, res = 0;
@@ -765,7 +765,7 @@ MODRET set_proxyforwardto(cmd_rec *cmd) {
   CONF_ERROR(cmd, pstrcat(cmd->tmp_pool, "The ", param, " directive cannot be "
     "used on this system, as you do not have POSIX compliant regex support",
     NULL));
-#endif
+#endif /* PR_USE_REGEX */
 }
 
 /* usage: ProxyLog path|"none" */
@@ -1476,7 +1476,7 @@ static mode_t extract_mode(struct stat *st) {
 
   mode = st->st_mode;
   mode &= ~S_IFMT;
-#ifdef S_IFJOURNAL
+#if defined(S_IFJOURNAL)
   /* AIX uses this non-standard bit, which can cause issues. */
   mode &= ~S_IFJOURNAL;
 #endif /* S_IFJOURNAL */
@@ -3521,7 +3521,7 @@ MODRET proxy_eprt(cmd_rec *cmd, struct proxy_session *proxy_sess) {
       (char *) cmd->argv[1], strerror(xerrno));
 
     if (xerrno == EPROTOTYPE) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
       if (pr_netaddr_use_ipv6()) {
         pr_response_add_err(R_522,
           _("Network protocol not supported, use (1,2)"));
@@ -3892,7 +3892,7 @@ MODRET proxy_pasv(cmd_rec *cmd, struct proxy_session *proxy_sess) {
    */
 
   if (pr_netaddr_get_family(session.c->local_addr) == pr_netaddr_get_family(session.c->remote_addr)) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     if (pr_netaddr_use_ipv6()) {
       /* Make sure that the family is NOT IPv6, even though the family of the
        * local and remote ends match.  The PASV command cannot be used for
@@ -4084,7 +4084,7 @@ MODRET proxy_port(cmd_rec *cmd, struct proxy_session *proxy_sess) {
   }
 
   if (allow_foreign_address == FALSE) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
     if (pr_netaddr_use_ipv6()) {
       /* We can only compare the PORT-given address against the remote client
        * address if the remote client address is an IPv4-mapped IPv6 address.

--- a/t/api/forward.c
+++ b/t/api/forward.c
@@ -447,7 +447,7 @@ END_TEST
 START_TEST (forward_handle_pass_noproxyauth_test) {
   int res, successful = FALSE, block_responses = FALSE;
   cmd_rec *cmd;
-#ifdef PR_USE_OPENSSL
+#if defined(PR_USE_OPENSSL)
   config_rec *c;
 #endif /* PR_USE_OPENSSL */
   struct proxy_session *proxy_sess;
@@ -501,7 +501,7 @@ START_TEST (forward_handle_pass_noproxyauth_test) {
       strerror(errno), errno);
   }
 
-#ifdef PR_USE_OPENSSL
+#if defined(PR_USE_OPENSSL)
   /* This time, try an FTPS-capable site. */
 
   session.notes = pr_table_alloc(p, 0);

--- a/t/api/ftp/msg.c
+++ b/t/api/ftp/msg.c
@@ -235,7 +235,7 @@ START_TEST (parse_addr_test) {
   ck_assert_msg(ntohs(pr_netaddr_get_port(res)) == 2121,
     "Expected 2121, got %u", ntohs(pr_netaddr_get_port(res)));
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   msg = "(127,0,0,1,8,73)";
   res = proxy_ftp_msg_parse_addr(p, msg, AF_INET);
   ck_assert_msg(res != NULL, "Failed to parse message '%s': %s", msg,
@@ -421,7 +421,7 @@ START_TEST (parse_ext_addr_test) {
   ck_assert_msg(errno == EPERM, "Expected EPERM (%d), got %s (%d)", EPERM,
     strerror(errno), errno);
 
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   addr = pr_netaddr_get_addr(p, "::1", NULL);
   ck_assert_msg(addr != NULL, "Failed to get address for ::1: %s",
     strerror(errno));

--- a/t/api/ftp/sess.c
+++ b/t/api/ftp/sess.c
@@ -98,7 +98,7 @@ START_TEST (send_auth_tls_test) {
 
   mark_point();
   res = proxy_ftp_sess_send_auth_tls(p, proxy_sess);
-#ifdef PR_USE_OPENSSL
+#if defined(PR_USE_OPENSSL)
   ck_assert_msg(res < 0, "Sent AUTH TLS unexpectedly");
   ck_assert_msg(errno == EINVAL, "Expected EINVAL (%d), got '%s' (%d)", EINVAL,
     strerror(errno), errno);

--- a/t/api/inet.c
+++ b/t/api/inet.c
@@ -190,7 +190,7 @@ START_TEST (inet_connect_ipv4_test) {
 END_TEST
 
 START_TEST (inet_connect_ipv6_test) {
-#ifdef PR_USE_IPV6
+#if defined(PR_USE_IPV6)
   int res;
   conn_t *conn;
   const pr_netaddr_t *addr;

--- a/t/api/tests.h
+++ b/t/api/tests.h
@@ -53,11 +53,11 @@
 #include "proxy/ftp/sess.h"
 #include "proxy/ftp/xfer.h"
 
-#ifdef HAVE_CHECK_H
+#if defined(HAVE_CHECK_H)
 # include <check.h>
 #else
 # error "Missing Check installation; necessary for ProFTPD testsuite"
-#endif
+#endif /* HAVE_CHECK_H */
 
 int tests_rmpath(pool *p, const char *path);
 int tests_stubs_set_next_cmd(cmd_rec *cmd);


### PR DESCRIPTION
I find it more legible.